### PR TITLE
add CompatHelpers and cleanup package dependency

### DIFF
--- a/.github/CompatHelpers.yml
+++ b/.github/CompatHelpers.yml
@@ -1,0 +1,24 @@
+name: CompatHelper
+
+on:
+  schedule:
+    - cron: '00 00 * * *'
+
+jobs:
+  CompatHelper:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: ["1.0"]
+        julia-arch: [x86]
+        os: [ubuntu-latest]
+    steps:
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.julia-version }}
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/Project.toml
+++ b/Project.toml
@@ -4,18 +4,16 @@ version = "0.2.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
-ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
-ColorTypes = "0.7.4"
-FileIO = "1.0.1"
-Requires = "0.5.2"
+FileIO = "1"
+ImageCore = "0.8.1"
+OffsetArrays = "0.8, 0.9, 0.10, 0.11"
+Requires = "0.5.2, 1"
 julia = "1"
 
 [extras]

--- a/src/ImageShow.jl
+++ b/src/ImageShow.jl
@@ -2,7 +2,7 @@ module ImageShow
 
 using Requires
 using FileIO
-using ImageCore, OffsetArrays, Colors, FixedPointNumbers
+using ImageCore, OffsetArrays
 
 const _have_restrict=Ref(false)
 function _use_restrict(val::Bool)

--- a/test/writemime.jl
+++ b/test/writemime.jl
@@ -1,5 +1,4 @@
-using ImageShow, Colors, FixedPointNumbers, FileIO, OffsetArrays, PaddedViews
-import ImageCore: colorview, normedview
+using ImageShow, ImageCore, FileIO, OffsetArrays, PaddedViews
 # We jump through some hoops so that this test script may work
 # whether or not ImageTransformations (a fortiori Images) is loaded.
 # See below for details.


### PR DESCRIPTION
There're three things involved here:
* add a CompatHelper to send notifications for new dependency version
* remove Colors, ColorTypes and FixedPointNumbers from Project, these are reexported by `ImageCore v0.8.1`
* set up compat section for all denpendencies