### PR TITLE
Eliminate OffsetArrays dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,25 +1,24 @@
 name = "ImageShow"
 uuid = "4e3cecfd-b093-5904-9786-8bbb286a6a31"
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
-OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 FileIO = "1"
 ImageCore = "0.8.1"
-OffsetArrays = "0.8, 0.9, 0.10, 0.11"
 Requires = "0.5.2, 1"
 julia = "1"
 
 [extras]
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 PaddedViews = "5432bcbf-9aad-5242-b902-cca2824c8663"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ImageMagick", "PaddedViews", "Test"]
+test = ["ImageMagick", "OffsetArrays", "PaddedViews", "Test"]

--- a/src/ImageShow.jl
+++ b/src/ImageShow.jl
@@ -2,13 +2,17 @@ module ImageShow
 
 using Requires
 using FileIO
-using ImageCore, OffsetArrays
+using ImageCore
 
 const _have_restrict=Ref(false)
 function _use_restrict(val::Bool)
     _have_restrict[] = val
 end
 function __init__()
+    @require OffsetArrays="6fe1bfb0-de20-5000-8ca7-80f57d26f881" begin
+        Base.show(io::IO, mime::MIME"image/png", img::OffsetArrays.OffsetArray{C}; kwargs...) where C<:Colorant =
+            show(io, mime, parent(img); kwargs...)
+    end
     @require ImageTransformations="02fcd773-0e25-5acc-982a-7f6622650795" _use_restrict(true)
 end
 include("showmime.jl")

--- a/src/showmime.jl
+++ b/src/showmime.jl
@@ -46,9 +46,6 @@ function Base.show(io::IO, mime::MIME"image/png", img::AbstractMatrix{C};
     end
 end
 
-Base.show(io::IO, mime::MIME"image/png", img::OffsetArray{C}; kwargs...) where C<:Colorant =
-    show(io, mime, parent(img); kwargs...)
-
 # Not all colorspaces are supported by all backends, so reduce types to a minimum
 csnormalize(c::AbstractGray) = Gray(c)
 csnormalize(c::Color) = RGB(c)


### PR DESCRIPTION
This [`collect` call](https://github.com/JuliaImages/ImageShow.jl/blob/f32179f2d572cfb0e07419f1551806dbc55a6329/src/showmime.jl#L28-L30) handles offset axes quite generally, so the specialized method is mostly redundant. It does, however, reduce memory consumption, so I decided to keep it but put it behind a `@require`. Since we're already using Requires in this package, that doesn't seem like unnecessary overhead.

The main advantage of eliminating unnecessary dependencies is less CompatHelper busy work.