### PR TITLE
add `play`/`explore` method to interactively view 3d image or framestack

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Things that users of `ImageShow` need to know:
 This package provides three non-exported functions `play`/`explore` and `gif` to interpret your 3D
 image or 2d images as either a video sequence or a gif.
 
-- `play`/`explore` are interactive tools; it show images frame by frame as video sequence.
+- (Experimental) `play`/`explore` are interactive tools; it show images frame by frame as video sequence.
 - `gif` is non-interactive; it encodes the image as gif.
 
 Feel free to replace `gif` with `play`/`explore` and see how it works:

--- a/README.md
+++ b/README.md
@@ -21,23 +21,30 @@ Things that users of `ImageShow` need to know:
 
 ## Functions
 
-This package also provides a non-exported function `gif` to interpret your 3D image or 2d images as
-an animated GIF image. (Only available for Julia at least v1.3.0)
+This package provides three non-exported functions `play`/`explore` and `gif` to interpret your 3D
+image or 2d images as either a video sequence or a gif.
+
+- `play`/`explore` are interactive tools; it show images frame by frame as video sequence.
+- `gif` is non-interactive; it encodes the image as gif.
+
+Feel free to replace `gif` with `play`/`explore` and see how it works:
 
 ```julia
 using ImageShow, TestImages, ImageTransformations
 
 # 3d image
-ImageShow.gif(testimage("mri-stack"))
+img3d = testimage("mri-stack") |> collect
+ImageShow.gif(img3d)
 
 # 2d images
 toucan = testimage("toucan") # 150×162 RGBA image
 moon = testimage("moon") # 256×256 Gray image
-ImageShow.gif([toucan, moon])
+framestack = [toucan, moon];
+ImageShow.gif(framestack)
 
 # a do-function version
 img = testimage("cameraman")
-ImageShow.gif(-π/4:π/16:π/4; fps=3) do θ
+ImageShow.gif(-π/4:π/64:π/4; fps=10) do θ
     imrotate(img, θ, axes(img))
 end
 ```

--- a/src/ImageShow.jl
+++ b/src/ImageShow.jl
@@ -17,6 +17,7 @@ function __init__()
 end
 include("showmime.jl")
 include("gif.jl")
+include("multipage.jl")
 include("compat.jl")
 
 # facilitate testing from importers

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -4,3 +4,8 @@ if isdefined(FileIO, :action)
 else
     _format_stream(format, io) = FileIO.Stream(format, io)
 end
+
+
+if VERSION < v"1.2.0"
+    isnothing(x) = x === nothing
+end

--- a/src/keyboard.jl
+++ b/src/keyboard.jl
@@ -1,0 +1,61 @@
+# minimal keyboard event support
+"""
+    read_key() -> control_value
+
+read control key from keyboard input.
+
+# Reference table
+
+| value               | control_value     | effect                 |
+| ------------------- | ----------------- | -------------------    |
+| UP, LEFT, b         | :CONTROL_BACKWARD | show previous frame    |
+| DOWN, RIGHT, f      | :CONTROL_FORWARD  | show next frame        |
+| SPACE, p            | :CONTROL_PAUSE    | pause/resume play      |
+| CTRL-c, q           | :CONTROL_EXIT     | exit current play      |
+| others...           | :CONTROL_VOID     | no effect              |
+"""
+function read_key(io=stdin)
+    control_value = :CONTROL_VOID
+    try
+        _setraw!(io, true)
+        keyin = read(io, Char)
+        if keyin == '\e'
+            # some special keys are more than one byte, e.g., left key is `\e[D`
+            # reference: https://en.wikipedia.org/wiki/ANSI_escape_code
+            keyin = read(io, Char)
+            if keyin == '['
+                keyin = read(io, Char)
+                if keyin in ['A', 'D'] # up, left
+                    control_value = :CONTROL_BACKWARD
+                elseif keyin in ['B', 'C'] # down, right
+                    control_value = :CONTROL_FORWARD
+                end
+            end
+        elseif 'A' <= keyin <= 'Z' || 'a' <= keyin <= 'z'
+            keyin = lowercase(keyin)
+            if keyin == 'p'
+                control_value = :CONTROL_PAUSE
+            elseif keyin == 'q'
+                control_value = :CONTROL_EXIT
+            elseif keyin == 'f'
+                control_value = :CONTROL_FORWARD
+            elseif keyin == 'b'
+                control_value = :CONTROL_BACKWARD
+            end
+        elseif keyin == ' '
+            control_value = :CONTROL_PAUSE
+        end
+    catch e
+        if e isa InterruptException # Ctrl-C
+            control_value = :CONTROL_EXIT
+        else
+            rethrow(e)
+        end
+    finally
+        _setraw!(io, false)
+    end
+    return control_value
+end
+
+_setraw!(io::Base.TTY, raw) = ccall(:jl_tty_set_mode, Int32, (Ptr{Cvoid},Int32), io.handle, raw)
+_setraw!(::IO, raw) = nothing

--- a/src/multipage.jl
+++ b/src/multipage.jl
@@ -1,0 +1,186 @@
+ansi_moveup(n::Int) = string("\e[", n, "A")
+const ansi_movecol1 = "\e[1G"
+
+"""
+    play(framestack::AbstractVector{T}; kwargs...) where {T<:AbstractArray}
+    play(arr::T, dim::Int; kwargs...)
+
+Play a video of a framestack of image arrays, or 3D array along dimension `dim`.
+
+Control keys:
+- `p` or `space-bar`: pause/resume
+- `f`, `←`(left arrow), or `↑`(up arrow): step backward
+- `b`, `→`(right arrow), or `↓`(down arrow): step forward
+- `ctrl-c` or `q`: exit
+
+kwargs:
+
+- `fps::Real=30`
+
+# Examples
+
+```julia
+julia> using TestImages, ImageShow
+
+julia> img3d = testimage("mri-stack") |> collect;
+
+julia> ImageShow.play(img3d, 3)
+
+julia> framestack = [img3d[:, :, i] for i in axes(img3d, 3)];
+
+julia> ImageShow.play(framestack)
+```
+"""
+function play(framestack::AbstractVector{<:AbstractArray}; fps::Real=30, paused=false)
+    nframes = length(framestack)
+
+    # vars
+    frame_idx = 1
+    actual_fps = 0
+    should_exit = false
+
+    function render_frame(frame_idx, actual_fps; first_frame)
+        frame = framestack[frame_idx]
+        cols, rows = size(frame)
+
+        if !first_frame
+            print(ansi_moveup(2), ansi_movecol1)
+        end
+        println("Frame: $frame_idx/$nframes FPS: $(round(actual_fps, digits=1))", " "^5)
+        println("exit: ctrl-c. play/pause: space-bar. seek: arrow keys")
+
+        display(frame)
+    end
+    render_frame(frame_idx, actual_fps; first_frame=true)
+
+    keytask = @async begin
+        while !should_exit
+            control_value = read_key()
+
+            if control_value == :CONTROL_BACKWARD
+                frame_idx = max(frame_idx-1, 1)
+            elseif control_value == :CONTROL_FORWARD
+                frame_idx = min(frame_idx+1, nframes)
+            elseif control_value == :CONTROL_PAUSE
+                paused = !paused
+            elseif control_value == :CONTROL_EXIT
+                should_exit = true
+            elseif control_value == :CONTROL_VOID
+                nothing
+            else
+                error("Control value $control_value not recognized.")
+            end
+        end
+    end
+
+    try
+        last_frame_idx = frame_idx
+
+        while !should_exit && 1<= frame_idx <= nframes
+            # when paused, only update the frame when last_frame_idx changes, i.e., only when
+            # user hit arrow keys.
+            if frame_idx != last_frame_idx
+                fps_value = paused ? 0 : actual_fps
+                actual_fps = fixed_fps(fps) do
+                    render_frame(frame_idx, actual_fps; first_frame=false)
+                end
+                last_frame_idx = frame_idx
+            end
+            paused || (frame_idx += 1)
+            paused && sleep(0.001)
+        end
+    catch e
+        e isa InterruptException || rethrow(e)
+    finally
+        # stop running read_key task so that REPL/stdin is not blocked
+        @async Base.throwto(keytask, InterruptException())
+        wait(keytask)
+    end
+    return nothing
+end
+play(img::AbstractArray{<:Colorant}, dim; kwargs...) = play(map(i->selectdim(img, dim, i), axes(img, dim)); kwargs...)
+
+# minimal keyboard event support
+"""
+    read_key() -> control_value
+
+read control key from keyboard input.
+
+# Reference table
+
+| value               | control_value     | effect                 |
+| ------------------- | ----------------- | -------------------    |
+| UP, LEFT, f, F      | :CONTROL_BACKWARD | show previous frame    |
+| DOWN, RIGHT, b, B   | :CONTROL_FORWARD  | show next frame        |
+| SPACE, p, P         | :CONTROL_PAUSE    | pause/resume play      |
+| CTRL-c, q, Q        | :CONTROL_EXIT     | exit current play      |
+| others...           | :CONTROL_VOID     | no effect              |
+"""
+function read_key()
+    setraw!(io, raw) = ccall(:jl_tty_set_mode, Int32, (Ptr{Cvoid},Int32), io.handle, raw)
+    control_value = :CONTROL_VOID
+    try
+        setraw!(stdin, true)
+        keyin = read(stdin, Char)
+        if keyin == '\e'
+            # some special keys are more than one byte, e.g., left key is `\e[D`
+            # reference: https://en.wikipedia.org/wiki/ANSI_escape_code
+            keyin = read(stdin, Char)
+            if keyin == '['
+                keyin = read(stdin, Char)
+                if keyin in ['A', 'D'] # up, left
+                    control_value = :CONTROL_BACKWARD
+                elseif keyin in ['B', 'C'] # down, right
+                    control_value = :CONTROL_FORWARD
+                end
+            end
+        elseif 'A' <= keyin <= 'Z' || 'a' <= keyin <= 'z'
+            keyin = lowercase(keyin)
+            if keyin == 'p'
+                control_value = :CONTROL_PAUSE
+            elseif keyin == 'q'
+                control_value = :CONTROL_EXIT
+            elseif keyin == 'f'
+                control_value = :CONTROL_FORWARD
+            elseif keyin == 'b'
+                control_value = :CONTROL_BACKWARD
+            end
+        elseif keyin == ' '
+            control_value = :CONTROL_PAUSE
+        end
+    catch e
+        if e isa InterruptException # Ctrl-C
+            control_value = :CONTROL_EXIT
+        else
+            rethrow(e)
+        end
+    finally
+        setraw!(stdin, false)
+    end
+    return control_value
+end
+
+"""
+    fixed_fps(f::Function, fps::Real)
+
+Run function f() at a fixed fps rate if possible.
+
+Example:
+
+The following codes render the frames at a given fps 60.
+
+```julia
+while true
+    actual_fps = fixed_fps(60) do
+        render_frame(...)
+    end
+end
+```
+"""
+function fixed_fps(f, fps::Real)
+    tim = Timer(1/fps)
+    t = @elapsed f()
+    wait(tim)
+    close(tim)
+    return 1/t
+end

--- a/src/multipage.jl
+++ b/src/multipage.jl
@@ -7,7 +7,7 @@ const ansi_movecol1 = "\e[1G"
     play(framestack::AbstractVector{T}; kwargs...) where {T<:AbstractArray}
     play(arr::T, dim=3; kwargs...)
 
-Play a video of a framestack of image arrays, or 3D array along dimension `dim`.
+(Experimental) Play a video of a framestack of image arrays, or 3D array along dimension `dim`.
 
 !!! compat "ImageShow 0.3"
     The `play` function requires at least ImageShow 0.3.
@@ -48,7 +48,7 @@ play(img::AbstractArray{<:Colorant, 3}, dim=3; kwargs...) = play(map(i->selectdi
     play(f, Xs; kwargs...)
     play(f, Xs, Ys...; kwargs...)
 
-A lazy version of `play([f(X) for X in Xs]; kwargs...)` that allocates memory only when needed.
+(Experimental) A lazy version of `play([f(X) for X in Xs]; kwargs...)` that allocates memory only when needed.
 
 !!! compat "ImageShow 0.3"
     The `play` function requires at least ImageShow 0.3.
@@ -87,7 +87,7 @@ play(frames::AbstractMappedArray; kwargs...) = play(collect(frames); kwargs...)
     explore(framestack::AbstractVector{T}; kwargs...) where {T<:AbstractArray}
     explore(arr::T, dim=3; kwargs...)
 
-Play a video of a framestack of image arrays, or 3D array along dimension `dim`.
+(Experimental) Play a video of a framestack of image arrays, or 3D array along dimension `dim`.
 
 !!! compat "ImageShow 0.3"
     The `play` function requires at least ImageShow 0.3.
@@ -104,7 +104,7 @@ explore(img::AbstractArray{<:Colorant, 3}, dim=3; kwargs...) = explore(map(i->se
     explore(f, Xs; kwargs...)
     explore(f, Xs, Ys...; kwargs...)
 
-A lazy version of `explore([f(X) for X in Xs]; kwargs...)` that allocates memory only when needed.
+(Experimental)  A lazy version of `explore([f(X) for X in Xs]; kwargs...)` that allocates memory only when needed.
 """
 explore(f, arg1, args...; kwargs...) = explore(mappedarray(f, arg1, args...); kwargs...)
 # MappedArrays are not efficient here https://github.com/JuliaArrays/MappedArrays.jl/issues/46

--- a/test/keyboard.jl
+++ b/test/keyboard.jl
@@ -1,0 +1,36 @@
+using ImageShow
+using ImageShow: read_key
+
+@testset "keyboard" begin
+    # TODO: Ctrl-C (InterruptException) is not tested
+    @testset "read_key" begin
+        inputs = [
+            (UInt8['\e', '[', 'A'], :CONTROL_BACKWARD), # UP
+            (UInt8['\e', '[', 'D'], :CONTROL_BACKWARD), # LEFT
+            (UInt8['\e', '[', 'B'], :CONTROL_FORWARD), # DOWN
+            (UInt8['\e', '[', 'C'], :CONTROL_FORWARD), # RIGHT
+
+            (UInt8[' '],            :CONTROL_PAUSE), # SPACE
+            (UInt8['p'],            :CONTROL_PAUSE),
+            (UInt8['P'],            :CONTROL_PAUSE),
+            (UInt8['q'],            :CONTROL_EXIT),
+            (UInt8['Q'],            :CONTROL_EXIT),
+            (UInt8['f'],            :CONTROL_FORWARD),
+            (UInt8['F'],            :CONTROL_FORWARD),
+            (UInt8['b'],            :CONTROL_BACKWARD),
+            (UInt8['B'],            :CONTROL_BACKWARD),
+
+            # key events that currenctly has no effect
+
+            # although VIM users might want this :)
+            (UInt8['j'],            :CONTROL_VOID),
+            (UInt8['k'],            :CONTROL_VOID),
+            (UInt8['h'],            :CONTROL_VOID),
+            (UInt8['l'],            :CONTROL_VOID),
+        ]
+        for (chs, ref) in inputs
+            io = IOBuffer(chs)
+            @test ref == read_key(io)
+        end
+    end
+end

--- a/test/multipage.jl
+++ b/test/multipage.jl
@@ -1,0 +1,61 @@
+using ImageShow, ImageCore
+using TestImages, FileIO
+using Test
+
+function check_summary(n, msg)
+    function generate_summary_regex(n)
+        summary_regex = raw"Frame: \d+/\d+ FPS: \d+\.\d+\s+\nexit: ctrl-c\. play\/pause: space-bar\. seek: arrow keys\n"
+        Regex(mapreduce(i->summary_regex, (x,y)->x*raw".*"*y, 1:n))
+    end
+    function _check_summary(n, msg)
+        return !isnothing(match(generate_summary_regex(n), msg))
+    end
+
+    return _check_summary(n, msg) && !_check_summary(n+1, msg)
+end
+
+@testset "multipage" begin
+    @testset "play" begin
+        img = RGB.(testimage("mri-stack"))
+        framestack = [img[:, :, i] for i in 1:size(img, 3)]
+
+        workdir = "tmp"
+        mktempdir() do workdir
+            filename = joinpath(workdir, "multipage.png")
+            fn = open(filename, "w")
+            summary_output_io = IOBuffer()
+
+            save(filename, framestack[1])
+            frame_size = stat(filename).size
+            
+            # Case: quit immediately
+            key_input_io = IOBuffer(UInt8['q'])
+            ImageShow._play(framestack; fps=1, paused=false, quit_after_play=true, display_io=fn, summary_io=summary_output_io, keyboard_io=key_input_io)
+            summary_msg = String(take!(summary_output_io))
+            @test check_summary(2, summary_msg) # If paused=false, it will print summary twice
+            @test RGB.(load(filename)) == framestack[1]
+            @test 1 == stat(filename).size/frame_size
+
+            # Case: quit after all play
+            fn = open(filename, "w")
+            summary_output_io = IOBuffer()
+            # use a small fps to make sure each frame are actually written
+            ImageShow._play(framestack; fps=15, paused=false, quit_after_play=true, display_io=fn, summary_io=summary_output_io, keyboard_io=stdin)
+            summary_msg = String(take!(summary_output_io))
+            @test check_summary(length(framestack), summary_msg)
+            # FIXME: show method will append to the given file handler, however, PNG reader will only
+            #        read the first valid png data; all extra data block are discarded.
+            # This somehow still proves that we're writing more than one image to the display_io
+            @test RGB.(load(filename)) == framestack[1]
+            @test 20 < stat(filename).size/frame_size < length(framestack)
+        end
+    end
+
+    @testset "utils" begin
+        # Although it's a no-op, it gets blocked at fps=2, which is about 0.5 second
+        t = @elapsed ImageShow.fixed_fps(2) do
+            nothing
+        end
+        @test 0.4 < t < 0.6
+    end
+end

--- a/test/multipage.jl
+++ b/test/multipage.jl
@@ -96,7 +96,7 @@ end
         # Although it's a no-op, it gets blocked at fps=2, which is about 0.5 second
         f() = nothing
         f() # precompile it
-        t = @elapsed ImageShow.fixed_fps(f, 2)
-        @test 0.4 < t < 0.6
+        t = @elapsed ImageShow.fixed_fps(f, 0.5)
+        @test 1.5 < t < 2.5
     end
 end

--- a/test/multipage.jl
+++ b/test/multipage.jl
@@ -8,7 +8,7 @@ function check_summary(n, msg)
         Regex(mapreduce(i->summary_regex, (x,y)->x*raw".*"*y, 1:n))
     end
     function _check_summary(n, msg)
-        return !isnothing(match(generate_summary_regex(n), msg))
+        return match(generate_summary_regex(n), msg) !== nothing
     end
 
     return _check_summary(n, msg) && !_check_summary(n+1, msg)
@@ -19,43 +19,84 @@ end
         img = RGB.(testimage("mri-stack"))
         framestack = [img[:, :, i] for i in 1:size(img, 3)]
 
-        workdir = "tmp"
         mktempdir() do workdir
-            filename = joinpath(workdir, "multipage.png")
-            fn = open(filename, "w")
-            summary_output_io = IOBuffer()
+            tmpfile = joinpath(workdir, "multipage.png")
+            save(tmpfile, framestack[1])
+            frame_size = stat(tmpfile).size
 
-            save(filename, framestack[1])
-            frame_size = stat(filename).size
-            
-            # Case: quit immediately
+            # Case: quit immediately -- render once
+            summary_output_io = IOBuffer()
             key_input_io = IOBuffer(UInt8['q'])
-            ImageShow._play(framestack; fps=1, paused=false, quit_after_play=true, display_io=fn, summary_io=summary_output_io, keyboard_io=key_input_io)
+            open(tmpfile, "w") do fn
+                ImageShow._play(framestack; fps=1, paused=true, quit_after_play=true, display_io=fn, summary_io=summary_output_io, keyboard_io=key_input_io)
+            end
             summary_msg = String(take!(summary_output_io))
-            @test check_summary(2, summary_msg) # If paused=false, it will print summary twice
-            @test RGB.(load(filename)) == framestack[1]
-            @test 1 == stat(filename).size/frame_size
+            @test check_summary(1, summary_msg)
+            @test RGB.(load(tmpfile)) == framestack[1]
+            @test 1.0 == stat(tmpfile).size/frame_size
 
-            # Case: quit after all play
-            fn = open(filename, "w")
+            # Case: quit after one forward -- render twice
+            fn = open(tmpfile, "w")
             summary_output_io = IOBuffer()
-            # use a small fps to make sure each frame are actually written
-            ImageShow._play(framestack; fps=15, paused=false, quit_after_play=true, display_io=fn, summary_io=summary_output_io, keyboard_io=stdin)
+            key_input_io = IOBuffer(UInt8['f', 'q'])
+            open(tmpfile, "w") do fn
+                ImageShow._play(framestack; fps=5, paused=true, quit_after_play=true, display_io=fn, summary_io=summary_output_io, keyboard_io=key_input_io)
+            end
             summary_msg = String(take!(summary_output_io))
-            @test check_summary(length(framestack), summary_msg)
-            # FIXME: show method will append to the given file handler, however, PNG reader will only
+            @test check_summary(2, summary_msg)
+            # NOTE: show method will append to the given file handler, however, PNG reader will only
             #        read the first valid png data; all extra data block are discarded.
             # This somehow still proves that we're writing more than one image to the display_io
-            @test RGB.(load(filename)) == framestack[1]
-            @test 20 < stat(filename).size/frame_size < length(framestack)
+            @test RGB.(load(tmpfile)) == framestack[1]
+            @test 1.8 < stat(tmpfile).size/frame_size <= 2.2
+
+            # Case: quit after resume play -- render twice
+            summary_output_io = IOBuffer()
+            key_input_io = IOBuffer(UInt8[' ', 'q'])
+            open(tmpfile, "w") do fn
+                ImageShow._play(framestack; fps=5, paused=true, quit_after_play=true, display_io=fn, summary_io=summary_output_io, keyboard_io=key_input_io)
+            end
+            summary_msg = String(take!(summary_output_io))
+            @test check_summary(2, summary_msg)
+            # NOTE: show method will append to the given file handler, however, PNG reader will only
+            #        read the first valid png data; all extra data block are discarded.
+            # This somehow still proves that we're writing more than one image to the display_io
+            @test RGB.(load(tmpfile)) == framestack[1]
+            @test 1.8 < stat(tmpfile).size/frame_size <= 2.2
+
+            # Case: quit after a useless control -- only render once
+            summary_output_io = IOBuffer()
+            key_input_io = IOBuffer(UInt8['b', '?', 'q'])
+            open(tmpfile, "w") do fn
+                ImageShow._play(framestack; fps=5, paused=true, quit_after_play=true, display_io=fn, summary_io=summary_output_io, keyboard_io=key_input_io)
+            end
+            summary_msg = String(take!(summary_output_io))
+            @test check_summary(1, summary_msg)
+            @test RGB.(load(tmpfile)) == framestack[1]
+            @test 1.0 == stat(tmpfile).size/frame_size
+
+            # Case: quit after all play
+            summary_output_io = IOBuffer()
+            key_input_io = IOBuffer()
+            # use a small fps to make sure each frame are actually written
+            open(tmpfile, "w") do fn
+                ImageShow._play(framestack; fps=15, paused=false, quit_after_play=true, display_io=fn, summary_io=summary_output_io, keyboard_io=key_input_io)
+            end
+            summary_msg = String(take!(summary_output_io))
+            @test check_summary(length(framestack), summary_msg)
+            # NOTE: show method will append to the given file handler, however, PNG reader will only
+            #        read the first valid png data; all extra data block are discarded.
+            # This somehow still proves that we're writing more than one image to the display_io
+            @test RGB.(load(tmpfile)) == framestack[1]
+            @test 0.8*length(framestack) < stat(tmpfile).size/frame_size < length(framestack)
         end
     end
 
     @testset "utils" begin
         # Although it's a no-op, it gets blocked at fps=2, which is about 0.5 second
-        t = @elapsed ImageShow.fixed_fps(2) do
-            nothing
-        end
+        f() = nothing
+        f() # precompile it
+        t = @elapsed ImageShow.fixed_fps(f, 2)
         @test 0.4 < t < 0.6
     end
 end

--- a/test/multipage.jl
+++ b/test/multipage.jl
@@ -4,7 +4,7 @@ using Test
 
 function check_summary(n, msg)
     function generate_summary_regex(n)
-        summary_regex = raw"Frame: \d+/\d+ FPS: \d+\.\d+\s+\nexit: ctrl-c\. play\/pause: space-bar\. seek: arrow keys\n"
+        summary_regex = raw"""Frame: \d+/\d+ FPS: \d+\.\d+\s+\nexit: "q" play\/pause: "space-bar" seek: "arrow keys"\n"""
         Regex(mapreduce(i->summary_regex, (x,y)->x*raw".*"*y, 1:n))
     end
     function _check_summary(n, msg)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,6 @@ using Test
         include("gif.jl")
     end
 
-    @info "There are some keyboard IO tests. To make sure test passes as expected, please don't press any key until test finishes."
     include("keyboard.jl")
     include("multipage.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,4 +7,8 @@ using Test
     if VERSION >= v"1.3.0"
         include("gif.jl")
     end
+
+    @info "There are some keyboard IO tests. To make sure test passes as expected, please don't press any key until test finishes."
+    include("keyboard.jl")
+    include("multipage.jl")
 end


### PR DESCRIPTION
Rework https://github.com/JuliaImages/ImageInTerminal.jl/pull/43, I've removed the codes related to terminal rendering in this PR to adapt vscode/atom display, I'd prefer to pend the terminal rendering functionality until this is done.

In short words, `play` method provides an interactive alternative to gif view.

Hopefully, we could make this implementation the default `Base.show` method for 3d image. I'm not sure of it, so I didn't export the name `play` yet.

Feedback, review, and any kind of features suggestions are welcome.

preview:

![2021-03-09 16-34-36 2021-03-09 16_35_54](https://user-images.githubusercontent.com/8684355/110442327-afd13b80-80f5-11eb-905a-23c97604de2d.gif)

Unlike [the original PR](https://github.com/JuliaImages/ImageInTerminal.jl/pull/43), `play` method here supports framestack of different image sizes (see the second demo gif).

![2021-03-09 16-42-04 2021-03-09 16_42_55](https://user-images.githubusercontent.com/8684355/110443107-88c73980-80f6-11eb-806f-e89cb08d30ee.gif)

cc: @IanButterworth