### PR TITLE
add `gif` function

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
         version:
           - '1.0'
           - '1'
-#          - 'nightly'
+          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -8,18 +8,21 @@ FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+StackViews = "cae243ae-269e-4f55-b966-ac2d0dc13c15"
 
 [compat]
 FileIO = "1"
 ImageCore = "0.8.1"
 OffsetArrays = "0.8, 0.9, 0.10, 0.11, 1"
 Requires = "0.5.2, 1"
+StackViews = "0.1.1"
 julia = "1"
 
 [extras]
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
-PaddedViews = "5432bcbf-9aad-5242-b902-cca2824c8663"
+ImageQualityIndexes = "2996bd0c-7a13-11e9-2da2-2f5ce47296a9"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [targets]
-test = ["ImageMagick", "PaddedViews", "Test"]
+test = ["ImageMagick", "ImageQualityIndexes", "Test", "TestImages"]

--- a/Project.toml
+++ b/Project.toml
@@ -19,10 +19,11 @@ StackViews = "0.1.1"
 julia = "1"
 
 [extras]
+ImageDistances = "51556ac3-7006-55f5-8cb3-34580c88182d"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
-ImageQualityIndexes = "2996bd0c-7a13-11e9-2da2-2f5ce47296a9"
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [targets]
-test = ["ImageMagick", "ImageQualityIndexes", "Test", "TestImages"]
+test = ["ImageDistances", "ImageMagick", "Suppressor", "Test", "TestImages"]

--- a/README.md
+++ b/README.md
@@ -10,16 +10,41 @@ graphical platforms such as [IJulia](https://github.com/JuliaLang/IJulia.jl),
 It is intended to provide convenient
 inline presentation of greyscale or color images.
 
-The intention is that this package will be invisible to most users; it
-should typically be invoked by other library packages. Of course, power users
-are invited to check out the test suite to see what we think you might do,
-and to suggest enhancements.
 
-One user-apparent aspect (for users with good vision) is that large
-images are displayed with anti-aliased reduction if the
-ImageTransformations package is loaded, but with simple down-sampling
-otherwise. (ImageTransformations is notably imported by Images, so
-`using Images` will provide the nicer display.)
+Things that users of `ImageShow` might need to know:
+
+* Once you load this package, `AbstractMatrix{<:Colorant}` will be displayed as PNG image.
+* Advanced anti-aliased reduction is applied if `ImageTransformations` are loaded.
+* `using Images` automatically loads `ImageShow` and `ImageTransformations` for you.
+
+## Functions
+
+This package also provides a non-exported function `gif` to interpret your 3D image or 2d images as
+an animated GIF image.
+
+```julia
+using ImageShow, TestImages, ImageTransformations
+# Or
+# using Images, TestImages
+
+# 3d image
+ImageShow.gif(testimage("mri-stack"))
+
+# 2d images
+toucan = testimage("toucan") # 150×162 RGBA image
+moon = testimage("moon") # 256×256 Gray image
+ImageShow.gif([toucan, moon])
+
+# a do-function version
+img = testimage("cameraman")
+ImageShow.gif(-π/4:π/16:π/4]; fps=3) do θ
+    imrotate(img, θ, axes(img))
+end
+```
+
+See also `mosaic`, provided by `MosaicViews`/`ImageCore`, for a 2d alternative of `gif`.
+
+# Acknowledgement
 
 The functionality of ImageShow has historically been included in the
 Images umbrella package.

--- a/README.md
+++ b/README.md
@@ -10,22 +10,22 @@ graphical platforms such as [IJulia](https://github.com/JuliaLang/IJulia.jl),
 It is intended to provide convenient
 inline presentation of greyscale or color images.
 
+Things that users of `ImageShow` need to know:
 
-Things that users of `ImageShow` might need to know:
-
-* Once you load this package, `AbstractMatrix{<:Colorant}` will be displayed as PNG image.
-* Advanced anti-aliased reduction is applied if `ImageTransformations` are loaded.
+* Without `ImageShow`, 2d image `AbstractMatrix{<:Colorant}` will be encoded and displayed as a SVG image, which is not performant
+  for generic image.
+* Once you load this package, 2d image will be encoded and displayed as a PNG image. To encode the
+  data as PNG image, either `ImageIO` or `ImageMagick` should be installed.
+* Advanced anti-aliased reduction is applied if `ImageTransformations` is loaded.
 * `using Images` automatically loads `ImageShow` and `ImageTransformations` for you.
 
 ## Functions
 
 This package also provides a non-exported function `gif` to interpret your 3D image or 2d images as
-an animated GIF image.
+an animated GIF image. (Only available for Julia at least v1.3.0)
 
 ```julia
 using ImageShow, TestImages, ImageTransformations
-# Or
-# using Images, TestImages
 
 # 3d image
 ImageShow.gif(testimage("mri-stack"))

--- a/src/ImageShow.jl
+++ b/src/ImageShow.jl
@@ -4,6 +4,10 @@ using Requires
 using FileIO
 using ImageCore, OffsetArrays
 
+using StackViews
+using ImageCore.MappedArrays
+using ImageCore.PaddedViews
+
 const _have_restrict=Ref(false)
 function _use_restrict(val::Bool)
     _have_restrict[] = val

--- a/src/ImageShow.jl
+++ b/src/ImageShow.jl
@@ -12,6 +12,7 @@ function __init__()
     @require ImageTransformations="02fcd773-0e25-5acc-982a-7f6622650795" _use_restrict(true)
 end
 include("showmime.jl")
+include("gif.jl")
 
 # facilitate testing from importers
 testdir() = joinpath(@__DIR__,"..","test")

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -1,6 +1,6 @@
 if isdefined(FileIO, :action)
     # FileIO >= 1.6
-    _png_stream(io) = FileIO.Stream{format"PNG"}(io)
+    _format_stream(format, io) = FileIO.Stream{format}(io)
 else
-    _png_stream(io) = FileIO.Stream(format"PNG", io)
+    _format_stream(format, io) = FileIO.Stream(format, io)
 end

--- a/src/gif.jl
+++ b/src/gif.jl
@@ -1,14 +1,19 @@
 struct AnimatedGIF{A<:AbstractArray}
     data::A
+    fps::Float64
+
+    function AnimatedGIF(data::A; fps=10) where A<:AbstractArray
+        new{A}(data, fps)
+    end
 end
 
 Base.showable(::MIME"image/gif", agif::AnimatedGIF) = true
 function Base.show(io::IO, ::MIME"image/gif", agif::AnimatedGIF)
-    FileIO.save(FileIO.Stream(format"GIF", io), agif.data)
+    FileIO.save(_format_stream(format"GIF", io), agif.data; fps=agif.fps)
 end
 
 """
-    @gif img
+    @gif img [fps=10]
 
 If displayable, display 3D image `img` as animated gif.
 
@@ -24,10 +29,16 @@ julia> ImageShow.@gif testimage("mri-stack")
     `ImageMagick` backend is required to generate gif. You can install it via
     `pkg> add ImageMagick`.
 """
-macro gif(img)
-    if displayable(MIME"image/gif"())
-        :(AnimatedGIF($(esc(img))))
-    else
-        esc(img)
+macro gif(img, kws...)
+    if !displayable(MIME"image/gif"())
+        return esc(img)
     end
+
+    expr = :(AnimatedGIF($(esc(img))))
+    for kw in kws
+        (kw isa Expr && kw.head == :(=)) || error("invalid signature for @gif")
+        k, v = kw.args
+        push!(expr.args, Expr(:kw, k, esc(v)))
+    end
+    return expr
 end

--- a/src/gif.jl
+++ b/src/gif.jl
@@ -14,7 +14,8 @@ struct AnimatedGIF{T, A<:AbstractArray} <: AbstractArray{T, 3}
 end
 AnimatedGIF(data::AbstractArray; kwargs...) = AnimatedGIF{eltype(data), typeof(data)}(data; kwargs...)
 
-Base.showable(::MIME"image/gif", agif::AnimatedGIF) = true
+# Display gif requires ImageMagick v1.2.0, which requires Julia 1.3
+Base.showable(::MIME"image/gif", agif::AnimatedGIF) = VERSION >= v"1.3.0"
 function Base.show(io::IO, ::MIME"image/gif", agif::AnimatedGIF)
     FileIO.save(_format_stream(format"GIF", io), agif.data; fps=agif.fps)
 end
@@ -28,6 +29,10 @@ Base.@propagate_inbounds Base.getindex(A::AnimatedGIF, inds::Vararg{Int}) = geti
     gif(frames; kwargs...)
 
 Convert 3D `img` or 2D frame list `frames` to animated gif array.
+
+!!! compat "ImageMagick 1.2"
+    `ImageMagick` at least v1.2.0 (which requires Julia at least v1.3.0) is required to generate
+    gif image. You can install it via `pkg> add ImageMagick`.
 
 # Arguments
 
@@ -54,10 +59,6 @@ using TestImages, ImageShow, ImageTransformations
 img = testimage("cameraman")
 ImageShow.gif([imrotate(img, θ, axes(img)) for θ in -π/4:π/16:π/4]; fps=3)
 ```
-
-!!! note
-    `ImageMagick` backend is required to generate gif. You can install it via
-    `pkg> add ImageMagick`.
 
 See also `mosaic`, provided by `MosaicViews`/`ImageCore`, for a 2d alternative of `gif`.
 """

--- a/src/gif.jl
+++ b/src/gif.jl
@@ -1,44 +1,117 @@
-struct AnimatedGIF{A<:AbstractArray}
+struct AnimatedGIF{T, A<:AbstractArray} <: AbstractArray{T, 3}
     data::A
-    fps::Float64
+    fps::Int
 
-    function AnimatedGIF(data::A; fps=10) where A<:AbstractArray
-        new{A}(data, fps)
+    # NOTE: the default fps is chosen purely by experience and may be changed in the future
+    function AnimatedGIF{T, A}(data::A; fps::Real=min(10, size(data, 3)÷2)) where {T, A<:AbstractArray}
+        if fps < 1
+            fps = 1
+            @warn "FPS should be larger than 1" FPS=fps
+        end
+
+        new{T, A}(data, ceil(Int, fps))
     end
 end
+AnimatedGIF(data::AbstractArray; kwargs...) = AnimatedGIF{eltype(data), typeof(data)}(data; kwargs...)
 
 Base.showable(::MIME"image/gif", agif::AnimatedGIF) = true
 function Base.show(io::IO, ::MIME"image/gif", agif::AnimatedGIF)
     FileIO.save(_format_stream(format"GIF", io), agif.data; fps=agif.fps)
 end
 
-"""
-    @gif img [fps=10]
+Base.size(A::AnimatedGIF) = size(A.data)
+Base.axes(A::AnimatedGIF) = axes(A.data)
+Base.@propagate_inbounds Base.getindex(A::AnimatedGIF, inds::Vararg{Int}) = getindex(A.data, inds...)
+Base.@propagate_inbounds Base.setindex!(A::AnimatedGIF, value, inds::Vararg{Int}) = setindex!(A.data, value, inds...)
 
-If displayable, display 3D image `img` as animated gif.
+"""
+    gif(img; kwargs...)
+    gif(frames; kwargs...)
+
+Convert 3D `img` or 2D frame list `frames` to animated gif array.
+
+# Arguments
+
+- `img::AbstractArray{T, 3}`: the last dimension is time axis.
+- `frames`: vector of 2d arrays.
+
+# Parameters
+
+- `fps::Int`: frame per second.
 
 # Examples:
 
-```julia
-julia> using ImageShow, TestImages
+You can use this to view a 3D image:
 
-julia> ImageShow.@gif testimage("mri-stack")
+```julia
+using ImageShow, TestImages
+ImageShow.gif(testimage("mri-stack"))
+```
+
+Or use it to dynamically check how different parameters change the function behavior:
+
+```julia
+using TestImages, ImageShow, ImageTransformations
+img = testimage("cameraman")
+ImageShow.gif([imrotate(img, θ, axes(img)) for θ in -π/4:π/16:π/4]; fps=3)
 ```
 
 !!! note
     `ImageMagick` backend is required to generate gif. You can install it via
     `pkg> add ImageMagick`.
 """
-macro gif(img, kws...)
-    if !displayable(MIME"image/gif"())
-        return esc(img)
-    end
+gif(img::AbstractArray{<:Colorant, 3}; kwargs...) = AnimatedGIF(img; kwargs...)
+gif(img::AbstractArray{<:Real, 3}; kwargs...) = AnimatedGIF(of_eltype(Gray, img); kwargs...)
+function gif(frames::AbstractVector{<:AbstractMatrix}; kwargs...)
+    FT = eltype(eltype(frames))
+    fillvalue = zero(FT) # require ColorVectorSpace for RGB and Gray
 
-    expr = :(AnimatedGIF($(esc(img))))
-    for kw in kws
-        (kw isa Expr && kw.head == :(=)) || error("invalid signature for @gif")
-        k, v = kw.args
-        push!(expr.args, Expr(:kw, k, esc(v)))
-    end
-    return expr
+    # FIXME: sym_paddedviews+StackView makes it unable to infer the types
+    # TODO: sym_paddedviews(zero(FT), frames...) would just break whatever the fancy lazy
+    #       feature `frames` has and thus slows the code
+    sz = size(first(frames))
+    frames = all(A->sz == size(A), frames) ? frames : sym_paddedviews(zero(FT), frames...)
+    stacked_frames = StackView{FT}(frames, Val(3))
+    gif(stacked_frames; kwargs...)
 end
+
+# Because any object can be callable (not just `Function`), we add this method to distinguish
+# the `f` function version and throw a menaingful message.
+# TODO: Maybe we could just support `gif(framestack...)`?
+gif(::AbstractMatrix, ::AbstractMatrix...) = throw(ArgumentError("Do you mean `gif([A, Bs...])"))
+
+"""
+    gif(f, Xs; kwargs...)
+    gif(f, Xs, Ys...; kwargs...)
+
+A lazy version of `gif([f(X) for X in Xs]; kwargs...)` that allocates memory only when needed.
+
+# Parameters
+
+- `fps::Int`: frame per second.
+
+# Examples 
+
+Rotate the image and see how things going:
+
+```julia
+using TestImages, ImageShow, ImageTransformations
+img = testimage("cameraman")
+ImageShow.gif(-π/4:π/16:π/4]; fps=3) do θ
+    imrotate(img, θ, axes(img))
+end
+```
+
+The following example is less meaningful, but it shows how multiple arguments are passed:
+
+```julia
+sizes = 16:4:64
+values = range(0, stop=1, length=length(sizes))
+gif = ImageShow.gif(values, sizes) do v, x
+    fill(RGB(v, v, v), ntuple(_->x, 2)...)
+end
+```
+"""
+gif(f, arg1, args...; kwargs...) = gif(mappedarray(f, arg1, args...); kwargs...)
+# MappedArrays are not efficient here https://github.com/JuliaArrays/MappedArrays.jl/issues/46
+gif(frames::AbstractMappedArray; kwargs...) = gif(collect(frames); kwargs...)

--- a/src/gif.jl
+++ b/src/gif.jl
@@ -26,7 +26,7 @@ julia> ImageShow.@gif testimage("mri-stack")
 """
 macro gif(img)
     if displayable(MIME"image/gif"())
-        :(display(AnimatedGIF($(esc(img)))))
+        :(AnimatedGIF($(esc(img))))
     else
         esc(img)
     end

--- a/src/gif.jl
+++ b/src/gif.jl
@@ -1,0 +1,33 @@
+struct AnimatedGIF{A<:AbstractArray}
+    data::A
+end
+
+Base.showable(::MIME"image/gif", agif::AnimatedGIF) = true
+function Base.show(io::IO, ::MIME"image/gif", agif::AnimatedGIF)
+    FileIO.save(FileIO.Stream(format"GIF", io), agif.data)
+end
+
+"""
+    @gif img
+
+If displayable, display 3D image `img` as animated gif.
+
+# Examples:
+
+```julia
+julia> using ImageShow, TestImages
+
+julia> ImageShow.@gif testimage("mri-stack")
+```
+
+!!! note
+    `ImageMagick` backend is required to generate gif. You can install it via
+    `pkg> add ImageMagick`.
+"""
+macro gif(img)
+    if displayable(MIME"image/gif"())
+        :(display(AnimatedGIF($(esc(img)))))
+    else
+        esc(img)
+    end
+end

--- a/src/gif.jl
+++ b/src/gif.jl
@@ -22,7 +22,6 @@ end
 Base.size(A::AnimatedGIF) = size(A.data)
 Base.axes(A::AnimatedGIF) = axes(A.data)
 Base.@propagate_inbounds Base.getindex(A::AnimatedGIF, inds::Vararg{Int}) = getindex(A.data, inds...)
-Base.@propagate_inbounds Base.setindex!(A::AnimatedGIF, value, inds::Vararg{Int}) = setindex!(A.data, value, inds...)
 
 """
     gif(img; kwargs...)
@@ -32,7 +31,7 @@ Convert 3D `img` or 2D frame list `frames` to animated gif array.
 
 # Arguments
 
-- `img::AbstractArray{T, 3}`: the last dimension is time axis.
+- `img::AbstractArray{T, 3}`: the last dimension is the time axis.
 - `frames`: vector of 2d arrays.
 
 # Parameters

--- a/src/gif.jl
+++ b/src/gif.jl
@@ -58,6 +58,8 @@ ImageShow.gif([imrotate(img, θ, axes(img)) for θ in -π/4:π/16:π/4]; fps=3)
 !!! note
     `ImageMagick` backend is required to generate gif. You can install it via
     `pkg> add ImageMagick`.
+
+See also `mosaic`, provided by `MosaicViews`/`ImageCore`, for a 2d alternative of `gif`.
 """
 gif(img::AbstractArray{<:Colorant, 3}; kwargs...) = AnimatedGIF(img; kwargs...)
 gif(img::AbstractArray{<:Real, 3}; kwargs...) = AnimatedGIF(of_eltype(Gray, img); kwargs...)

--- a/src/showmime.jl
+++ b/src/showmime.jl
@@ -40,9 +40,9 @@ function Base.show(io::IO, mime::MIME"image/png", img::AbstractMatrix{C};
             r[[coords_spatial(img)...]] .= fac
             img = repeat(img, inner=r)
         end
-        FileIO.save(_png_stream(io), img, mapi=mapi)
+        FileIO.save(_format_stream(format"PNG", io), img, mapi=mapi)
     else
-        FileIO.save(_png_stream(io), img)
+        FileIO.save(_format_stream(format"PNG", io), img)
     end
 end
 

--- a/test/gif.jl
+++ b/test/gif.jl
@@ -1,55 +1,67 @@
 using TestImages, ImageCore, ImageShow
-using Test
+using Test, Suppressor
 using FileIO
-using ImageQualityIndexes
+using ImageDistances
 
 @testset "GIF" begin
-    # TODO: the `fps` keyword is not tested
-
-    # ImageMagick saves GIF as RGB array
-    img = RGB.(testimage("mri-stack"))
-    ref_gif = ImageShow.gif(img)
-
-    @test !showable(MIME("image/gif"), img)
-    @test showable(MIME("image/gif"), ref_gif)
-
-    mktempdir() do workdir
-        fn = joinpath(workdir, "writemime.gif")
-        open(fn, "w") do file
-            show(file, MIME("image/gif"), ImageShow.gif(img))
-        end
-        @test load(fn) == ref_gif
-
-        framestack = [img[:, :, i] for i in axes(img, 3)]
-        fn = joinpath(workdir, "writemime.gif")
-        open(fn, "w") do file
-            show(file, MIME("image/gif"), ImageShow.gif(framestack))
-        end
-        @test load(fn) == ref_gif
-
-        toucan = testimage("toucan") # 150×162 RGBA image
-        moon = testimage("moon") # 256×256 Gray image
-        framestack = [toucan, moon]
-        fn = joinpath(workdir, "writemime.gif")
-        open(fn, "w") do file
-            show(file, MIME("image/gif"), ImageShow.gif(framestack))
-        end
-        @test assess_psnr(RGB.(load(fn)), RGB.(ImageShow.gif(framestack))) >= 40
-
-        sizes = 16:4:64
-        values = range(0, stop=1, length=length(sizes))
-        gif = ImageShow.gif(values, sizes) do v, x
-            fill(RGB(v, v, v), ntuple(_->x, 2)...)
-        end
-        fn = joinpath(workdir, "writemime.gif")
-        open(fn, "w") do file
-            show(file, MIME("image/gif"), gif)
-        end
-        @test assess_psnr(RGB.(load(fn)), gif) >= 60
-    end
-
-    # This might be a non-error in future
     toucan = testimage("toucan") # 150×162 RGBA image
     moon = testimage("moon") # 256×256 Gray image
+
+    # This might be a non-error in future
     @test_throws ArgumentError ImageShow.gif(toucan, moon)
+    warning_msg = Suppressor.@capture_err ImageShow.gif([toucan, moon]; fps=0.5)
+    @test contains(warning_msg, "FPS should be larger than 1")
+
+    @testset "show" begin
+        # TODO: the `fps` keyword is unable to test
+
+        img = RGB.(testimage("mri-stack")) # ImageMagick saves GIF as RGB/ARGB array
+        ref_gif = ImageShow.gif(img)
+
+        @test !showable(MIME("image/gif"), img)
+        @test showable(MIME("image/gif"), ref_gif)
+
+        workdir = "tmp"
+        mktempdir() do workdir
+            fn = joinpath(workdir, "writemime.gif")
+            open(fn, "w") do file
+                show(file, MIME("image/gif"), ImageShow.gif(img))
+            end
+            @test load(fn) == ref_gif
+
+            framestack = [img[:, :, i] for i in axes(img, 3)]
+            fn = joinpath(workdir, "writemime.gif")
+            open(fn, "w") do file
+                show(file, MIME("image/gif"), ImageShow.gif(framestack))
+            end
+            @test load(fn) == ref_gif
+
+            framestack = [toucan, moon]
+            fn = joinpath(workdir, "writemime.gif")
+            open(fn, "w") do file
+                show(file, MIME("image/gif"), ImageShow.gif(framestack))
+            end
+            @test euclidean(RGB.(load(fn)), RGB.(ImageShow.gif(framestack))) <= 5.5
+
+            sizes = 16:4:64
+            values = range(0, stop=1, length=length(sizes))
+            gif = ImageShow.gif(values, sizes) do v, x
+                fill(v, ntuple(_->x, 2)...)
+            end
+            fn = joinpath(workdir, "writemime.gif")
+            open(fn, "w") do file
+                show(file, MIME("image/gif"), gif)
+            end
+            @test euclidean(RGB.(load(fn)), RGB.(gif)) <= 0.5
+        end
+    end
+
+    @testset "gif as a readonly array" begin
+        A = fill(1.0, 4, 8)
+        B = fill(2.0, 2, 2)
+        gif = ImageShow.gif([A, B])
+        @test axes(gif) == (1:4, 1:8, 1:2)
+        cv = channelview(gif)
+        @test all(cv[:, :, 1] .== 1.0) && all(cv[2:3, 4:5, 2] .== 2.0)
+    end
 end

--- a/test/gif.jl
+++ b/test/gif.jl
@@ -61,6 +61,7 @@ using ImageDistances
         B = fill(2.0, 2, 2)
         gif = ImageShow.gif([A, B])
         @test axes(gif) == (1:4, 1:8, 1:2)
+        @test size(gif) == (4, 8, 2)
         cv = channelview(gif)
         @test all(cv[:, :, 1] .== 1.0) && all(cv[2:3, 4:5, 2] .== 2.0)
     end

--- a/test/gif.jl
+++ b/test/gif.jl
@@ -1,0 +1,55 @@
+using TestImages, ImageCore, ImageShow
+using Test
+using FileIO
+using ImageQualityIndexes
+
+@testset "GIF" begin
+    # TODO: the `fps` keyword is not tested
+
+    # ImageMagick saves GIF as RGB array
+    img = RGB.(testimage("mri-stack"))
+    ref_gif = ImageShow.gif(img)
+
+    @test !showable(MIME("image/gif"), img)
+    @test showable(MIME("image/gif"), ref_gif)
+
+    mktempdir() do workdir
+        fn = joinpath(workdir, "writemime.gif")
+        open(fn, "w") do file
+            show(file, MIME("image/gif"), ImageShow.gif(img))
+        end
+        @test load(fn) == ref_gif
+
+        framestack = [img[:, :, i] for i in axes(img, 3)]
+        fn = joinpath(workdir, "writemime.gif")
+        open(fn, "w") do file
+            show(file, MIME("image/gif"), ImageShow.gif(framestack))
+        end
+        @test load(fn) == ref_gif
+
+        toucan = testimage("toucan") # 150×162 RGBA image
+        moon = testimage("moon") # 256×256 Gray image
+        framestack = [toucan, moon]
+        fn = joinpath(workdir, "writemime.gif")
+        open(fn, "w") do file
+            show(file, MIME("image/gif"), ImageShow.gif(framestack))
+        end
+        @test assess_psnr(RGB.(load(fn)), RGB.(ImageShow.gif(framestack))) >= 40
+
+        sizes = 16:4:64
+        values = range(0, stop=1, length=length(sizes))
+        gif = ImageShow.gif(values, sizes) do v, x
+            fill(RGB(v, v, v), ntuple(_->x, 2)...)
+        end
+        fn = joinpath(workdir, "writemime.gif")
+        open(fn, "w") do file
+            show(file, MIME("image/gif"), gif)
+        end
+        @test assess_psnr(RGB.(load(fn)), gif) >= 60
+    end
+
+    # This might be a non-error in future
+    toucan = testimage("toucan") # 150×162 RGBA image
+    moon = testimage("moon") # 256×256 Gray image
+    @test_throws ArgumentError ImageShow.gif(toucan, moon)
+end

--- a/test/gif.jl
+++ b/test/gif.jl
@@ -10,7 +10,7 @@ using ImageDistances
     # This might be a non-error in future
     @test_throws ArgumentError ImageShow.gif(toucan, moon)
     warning_msg = Suppressor.@capture_err ImageShow.gif([toucan, moon]; fps=0.5)
-    @test contains(warning_msg, "FPS should be larger than 1")
+    @test occursin("FPS should be larger than 1", warning_msg)
 
     @testset "show" begin
         # TODO: the `fps` keyword is unable to test

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,10 @@
 using Test
 
 @testset "ImageShow" begin
-include("writemime.jl")
-include("gif.jl")
+    include("writemime.jl")
+
+    # `gif` requires ImageMagick v1.2.0, which requires Julia 1.3
+    if VERSION >= v"1.3.0"
+        include("gif.jl")
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,4 +2,5 @@ using Test
 
 @testset "ImageShow" begin
 include("writemime.jl")
+include("gif.jl")
 end

--- a/test/writemime.jl
+++ b/test/writemime.jl
@@ -1,4 +1,5 @@
-using ImageShow, ImageCore, FileIO, OffsetArrays, PaddedViews
+using ImageShow, ImageCore, FileIO, OffsetArrays
+using ImageCore: PaddedViews
 # We jump through some hoops so that this test script may work
 # whether or not ImageTransformations (a fortiori Images) is loaded.
 # See below for details.


### PR DESCRIPTION
Originally proposed in https://github.com/JuliaImages/ImageShow.jl/issues/22#issuecomment-616759613. This is a simple and yet powerful alternative to #29 for 3d image.

Example:

```julia
using ImageShow, TestImages, ImageTransformations

# 3d image
ImageShow.gif(testimage("mri-stack"))

# 2d images
toucan = testimage("toucan") # 150×162 RGBA image
moon = testimage("moon") # 256×256 Gray image
ImageShow.gif([toucan, moon])

# a do-function version
img = testimage("cameraman")
ImageShow.gif(-π/4:π/16:π/4]; fps=3) do θ
    imrotate(img, θ, axes(img))
end
```

- [x] requires https://github.com/JuliaIO/ImageMagick.jl/pull/199 (ImageMagick >= v1.2.0)
- [x] need test