### PR TITLE
[compat] support gif in Julia 1.0

### DIFF
--- a/src/gif.jl
+++ b/src/gif.jl
@@ -15,7 +15,7 @@ end
 AnimatedGIF(data::AbstractArray; kwargs...) = AnimatedGIF{eltype(data), typeof(data)}(data; kwargs...)
 
 # Display gif requires ImageMagick v1.2.0, which requires Julia 1.3
-Base.showable(::MIME"image/gif", agif::AnimatedGIF) = VERSION >= v"1.3.0"
+Base.showable(::MIME"image/gif", agif::AnimatedGIF) = true
 function Base.show(io::IO, ::MIME"image/gif", agif::AnimatedGIF)
     FileIO.save(_format_stream(format"GIF", io), agif.data; fps=agif.fps)
 end
@@ -31,8 +31,8 @@ Base.@propagate_inbounds Base.getindex(A::AnimatedGIF, inds::Vararg{Int}) = geti
 Convert 3D `img` or 2D frame list `frames` to animated gif array.
 
 !!! compat "ImageMagick 1.2"
-    `ImageMagick` at least v1.2.0 (which requires Julia at least v1.3.0) is required to generate
-    gif image. You can install it via `pkg> add ImageMagick`.
+    ImageMagick at least 1.2 is required to generate gif image. For ImageMagick 0.y.z versions,
+    ImageMagick at least 0.7.7 also works.
 
 # Arguments
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,11 +3,7 @@ using Test
 @testset "ImageShow" begin
     include("writemime.jl")
 
-    # `gif` requires ImageMagick v1.2.0, which requires Julia 1.3
-    if VERSION >= v"1.3.0"
-        include("gif.jl")
-    end
-
+    include("gif.jl")
     include("keyboard.jl")
     include("multipage.jl")
 end


### PR DESCRIPTION
I've backported https://github.com/JuliaIO/ImageMagick.jl/pull/199 to ImageMagick v0.7.7, thus `gif` also works for Julia 1.0 now.

Hope this is the last PR before the v0.3.0 release.