### PR TITLE
use standard MIT license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,14 +1,7 @@
-The ImageCore.jl package is licensed under the MIT "Expat" License:
+Copyright 2020 The JuliaImages developers
 
-> Copyright (c) 2018: The JuliaImages developers.
->
-> Permission is hereby granted, free of charge, to any person obtaining
-> a copy of this software and associated documentation files (the
-> "Software"), to deal in the Software without restriction, including
-> without limitation the rights to use, copy, modify, merge, publish,
-> distribute, sublicense, and/or sell copies of the Software, and to
-> permit persons to whom the Software is furnished to do so, subject to
-> the following conditions:
->
-> The above copyright notice and this permission notice shall be
-> included in all copies or substantial portions of the Software.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Now general registry CI uses LicenseCheck.jl to make sure each package
has its associated OSI license. The old ImageShow license is not
well-formatted and makes LicenseCheck unhappy.

https://github.com/JuliaRegistries/General/pull/34396

```julia
using LicenseCheck, ImageShow

read(joinpath(pkgdir(ImageShow), "LICENSE.md"), String) |> licensecheck
# PR: (licenses_found = ["MIT"], license_file_percent_covered = 100.0)
# master: (licenses_found = String[], license_file_percent_covered = 0.0)
```

cc: @RalphAS @timholy 