### PR TITLE
use `ImageBase.restrict`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,16 +5,16 @@ version = "0.3.1"
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+ImageBase = "c817782e-172a-44cc-b673-b171935fbb9e"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StackViews = "cae243ae-269e-4f55-b966-ac2d0dc13c15"
 
 [compat]
 FileIO = "1"
-ImageCore = "0.8.1, 0.9"
+ImageBase = "0.1"
+ImageCore = "0.9"
 OffsetArrays = "0.8, 0.9, 0.10, 0.11, 1"
-Requires = "0.5.2, 1"
 StackViews = "0.1.1"
 julia = "1"
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ Things that users of `ImageShow` need to know:
   for generic image.
 * Once you load this package, 2d image will be encoded and displayed as a PNG image. To encode the
   data as PNG image, either `ImageIO` or `ImageMagick` should be installed.
-* Advanced anti-aliased reduction is applied if `ImageTransformations` is loaded.
-* `using Images` automatically loads `ImageShow` and `ImageTransformations` for you.
+* `using Images` automatically loads `ImageShow` for you.
 
 ## Functions
 

--- a/src/ImageShow.jl
+++ b/src/ImageShow.jl
@@ -1,20 +1,13 @@
 module ImageShow
 
-using Requires
 using FileIO
 using ImageCore, OffsetArrays
+import ImageBase: restrict
 
 using StackViews
 using ImageCore.MappedArrays
 using ImageCore.PaddedViews
 
-const _have_restrict=Ref(false)
-function _use_restrict(val::Bool)
-    _have_restrict[] = val
-end
-function __init__()
-    @require ImageTransformations="02fcd773-0e25-5acc-982a-7f6622650795" _use_restrict(true)
-end
 include("showmime.jl")
 include("gif.jl")
 include("multipage.jl")

--- a/src/showmime.jl
+++ b/src/showmime.jl
@@ -30,7 +30,7 @@ function Base.show(io::IO, mime::MIME"image/png", img::AbstractMatrix{C};
     end
     if !get(io, :full_fidelity, false)
         while _length1(img) > maxpixels
-            img = _restrict1(img)  # big images
+            img = restrict(img)  # big images
         end
         npix = _length1(img)
         if npix < minpixels
@@ -122,16 +122,6 @@ function show_element(io::IOContext, img)
     show(b64pipe, MIME"image/png"(), im_resized)
     write(io, read(seekstart(io2)))
     write(io,"\">")
-end
-
-function _restrict1(img)
-    if _have_restrict[]
-        res = ImageTransformations.restrict(img)
-    else
-        @info "For better quality inline display of large images or thumbnails, load the Images package." maxlog=1
-        res = img[1:2:end,1:2:end]
-    end
-    res
 end
 
 _length1(A::AbstractArray) = length(eachindex(A))

--- a/test/writemime.jl
+++ b/test/writemime.jl
@@ -1,10 +1,6 @@
 using ImageShow, ImageCore, FileIO, OffsetArrays
 using ImageCore: PaddedViews
-# We jump through some hoops so that this test script may work
-# whether or not ImageTransformations (a fortiori Images) is loaded.
-# See below for details.
-
-# don't import ImageTransformations: restrict
+import ImageBase: restrict
 
 using Test
 
@@ -95,36 +91,13 @@ end
     end
 end
 
-# We do this after the FileIO backend has gotten comfortable.
-const have_restrict = Ref{Bool}(false)
-const restrict_mod = Ref{Module}()
-for mod in values(Base.loaded_modules)
-    if string(mod) == "ImageTransformations"
-        have_restrict[] = true
-        restrict_mod[] = mod
-    end
-end
-
-if have_restrict[]
-    @info "Tests will use restrict from ImageTransformations"
-    const restrict = restrict_mod[].restrict
-end
-
 @testset "Big images and matrices" begin
     @testset "big images (use of restrict)" begin
         A = N0f8[0.01 0.4 0.99; 0.25 0.8 0.75; 0.6 0.2 0.0]
-        if have_restrict[]
-            Ar = restrict(A)
-        else
-            Ar = N0f8[0.01 0.99; 0.6 0.0]
-        end
+        Ar = restrict(A)
         fn = joinpath(workdir, "writemime.png")
         open(fn, "w") do file
-            if !have_restrict[]
-                @test_logs (:info, r"^For better quality") show(file, MIME("image/png"), Gray.(A), minpixels=0, maxpixels=5)
-            else
-                show(file, MIME("image/png"), Gray.(A), minpixels=0, maxpixels=5)
-            end
+            show(file, MIME("image/png"), Gray.(A), minpixels=0, maxpixels=5)
         end
         @test load(fn) == N0f8.(Ar)
         # a genuinely big image (tests the defaults)
@@ -134,11 +107,7 @@ end
             show(file, MIME("image/png"), abig, maxpixels=10^6)
         end
         b = load(fn)
-        if have_restrict[]
-            btmp = restrict(abig, (1,2))
-        else
-            btmp = abig[1:2:end,1:2:end]
-        end
+        btmp = restrict(abig, (1,2))
         @test b == N0f8.(btmp)
     end
     @testset "display matrix of images" begin


### PR DESCRIPTION
Until now I realize that we never test `ImageTransformation.restrict` for more than 3 years given that it's not loaded at all.

```julia
julia> @time using ImageShow
# master: 1.113088 seconds (2.31 M allocations: 169.042 MiB, 5.48% gc time, 0.24% compilation time)
# PR:  1.177738 seconds (2.35 M allocations: 172.266 MiB, 4.79% gc time, 0.29% compilation time)
```
