### PR TITLE
Add HTML support for showing images

### DIFF
--- a/src/ImageShow.jl
+++ b/src/ImageShow.jl
@@ -1,5 +1,6 @@
 module ImageShow
 
+import Base64
 using FileIO
 using ImageCore, OffsetArrays
 import ImageBase: restrict

--- a/src/showmime.jl
+++ b/src/showmime.jl
@@ -153,7 +153,7 @@ function Base.show(io::IO, ::MIME"text/html", img::ColorantMatrix)
 end
 
 function _show_image_html(io, mimes::Vector{<:MIME}, x)
-    for mime in _HTML_IMAGE_MIMES
+    for mime in mimes
         if showable(mime, x)
             _show_image_html(io, mime, x)
             break

--- a/src/showmime.jl
+++ b/src/showmime.jl
@@ -129,7 +129,7 @@ end
 function downsize_for_thumbnail(img, w, h)
     a,b=size(img)
     a > 2w && b > 2h ?
-        downsize_for_thumbnail(_restrict1(img), w, h) : img
+        downsize_for_thumbnail(restrict(img), w, h) : img
 end
 
 show_element(io::IO, img, thumbnail=false; kw...) = show_element(IOContext(io), img, thumbnail; kw...)

--- a/src/showmime.jl
+++ b/src/showmime.jl
@@ -140,3 +140,29 @@ end
 
 _length1(A::AbstractArray) = length(eachindex(A))
 _length1(A) = length(A)
+
+
+
+const _HTML_IMAGE_MIMES = [
+    MIME("image/jpg"),
+    MIME("image/png"),
+]
+
+function Base.show(io::IO, ::MIME"text/html", img::ColorantMatrix)
+    _show_image_html(io, _HTML_IMAGE_MIMES, img)
+end
+
+function _show_image_html(io, mimes::Vector{<:MIME}, x)
+    for mime in _HTML_IMAGE_MIMES
+        if showable(mime, x)
+            _show_image_html(io, mime, x)
+            break
+        end
+    end
+end
+
+function _show_image_html(io, mime::MIME{Name}, x) where Name
+    buf = IOBuffer()
+    show(buf, mime, x)
+    print(io, """<img src="data:""", Name, ";base64,", Base64.base64encode(take!(buf)), "\" />")
+end

--- a/test/writemime.jl
+++ b/test/writemime.jl
@@ -153,6 +153,15 @@ end
         end
         @test load(fn) == A[[1,1,2,2],[1,1,2,2]]
     end
+    @testset "HTML display" begin
+        sshow(mime, x) = (io = IOBuffer(); show(io, mime, x); String(take!(io)))
+        @test startswith(
+            sshow(MIME("text/html"), zeros(Gray{Float32}, 1, 1)),
+            "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAAAAABV")
+        @test startswith(
+            sshow(MIME("text/html"), zeros(RGB{Float32}, 1, 1)),
+            "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAIAAAD/")
+    end
 end
 try
     # if this fails, it is not our fault

--- a/test/writemime.jl
+++ b/test/writemime.jl
@@ -157,10 +157,18 @@ end
         sshow(mime, x) = (io = IOBuffer(); show(io, mime, x); String(take!(io)))
         @test startswith(
             sshow(MIME("text/html"), zeros(Gray{Float32}, 1, 1)),
-            "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAAAAABV")
+            if VERSION >= v"1.3" # ImageIO
+                "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAAAAAB"
+            else # ImageMagick
+                "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkAQAAAAB"
+            end)
         @test startswith(
             sshow(MIME("text/html"), zeros(RGB{Float32}, 1, 1)),
-            "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAIAAAD/")
+            if VERSION >= v"1.3" # ImageIO
+                "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAIAAAD"
+            else # ImageMagick
+                "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkAQAAAABY"
+            end)
     end
 end
 try


### PR DESCRIPTION
Can't push to #49 so I open a new PR here. Changes on top of #49:

- set default format PNG, because PNG is lossless and supports transparency.
- reuse the `show_element` codes
- "fixes" the test on 1.0: this is because ImageIO is only available on Julia >= 1.3 and thus reference results may change.

closes #48
closes #49

cc: @lorenzoh