### PR TITLE
opt-in HTML render

### DIFF
--- a/src/ImageShow.jl
+++ b/src/ImageShow.jl
@@ -9,6 +9,13 @@ using StackViews
 using ImageCore.MappedArrays
 using ImageCore.PaddedViews
 
+# opt-in HTML render for image
+# work around https://github.com/JuliaImages/ImageShow.jl/pull/50#issuecomment-1124132500
+const _ENABLE_HTML = Ref(false)
+enable_html_render() = _ENABLE_HTML[] = true
+disable_html_render() = _ENABLE_HTML[] = false
+Base.showable(::MIME"text/html", ::AbstractMatrix{<:Colorant}) = _ENABLE_HTML[]
+
 include("showmime.jl")
 include("gif.jl")
 include("multipage.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,6 @@
 using Test
+using ImageShow
+ImageShow.enable_html_render()
 
 @testset "ImageShow" begin
     include("writemime.jl")


### PR DESCRIPTION
This is a quick patch to "fix" the Pluto compatibility issue https://github.com/JuliaImages/ImageShow.jl/pull/50#issuecomment-1124132500

Since this may affect potentially too many pluto notebooks, I decide to make it an opt-in feature. Eventually this will be opt-out when things get better supported. @lorenzoh Will this be okay to you?

cc: @fonsp @lorenzh