### PR TITLE
make default html show fullmode

### DIFF
--- a/src/showmime.jl
+++ b/src/showmime.jl
@@ -80,7 +80,7 @@ function _show_odd(io::IO, m::MIME"text/html", imgs::AbstractArray{T, 1}) where 
     # display a vector of images in a row
     for j in eachindex(imgs)
         write(io, "<td style='text-align:center;vertical-align:middle; margin: 0.5em;border:1px #90999f solid;border-collapse:collapse'>")
-        show_element(IOContext(io, :thumbnail => true), imgs[j])
+        show_element(IOContext(io, :thumbnail => true), imgs[j], true)
         write(io, "</td>")
     end
 end
@@ -133,7 +133,7 @@ function downsize_for_thumbnail(img, w, h)
 end
 
 show_element(io::IO, img, thumbnail=false; kw...) = show_element(IOContext(io), img, thumbnail; kw...)
-function show_element(io::IOContext, img, thumbnail=true; mimes=_HTML_IMAGE_MIMES)
+function show_element(io::IOContext, img, thumbnail=false; mimes=_HTML_IMAGE_MIMES)
     img = if thumbnail
         w,h=get(io, :thumbnailsize, (100,100))
         im_resized = downsize_for_thumbnail(img, w, h)

--- a/test/writemime.jl
+++ b/test/writemime.jl
@@ -155,6 +155,7 @@ end
     end
     @testset "HTML display" begin
         sshow(mime, x) = (io = IOBuffer(); show(io, mime, x); String(take!(io)))
+        sshow_context(mime, x) = (io = IOBuffer(); show(IOContext(io), mime, x); String(take!(io)))
         @test startswith(
             sshow(MIME("text/html"), zeros(Gray{Float32}, 1, 1)),
             if VERSION >= v"1.3" # ImageIO
@@ -169,6 +170,9 @@ end
             else # ImageMagick
                 "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkAQAAAABY"
             end)
+
+        img = rand(RGB, 512, 512)
+        @test sshow_context(MIME("text/html"), img) == sshow(MIME("text/html"), img)
     end
 end
 try


### PR DESCRIPTION
Resolves the comment in https://github.com/JuliaImages/ImageShow.jl/pull/51#issuecomment-1128766669
>  I still think that the downscaling done by the HTML show method can be confusing, because it happens secretly, and it is not possible to control this behaviour. 

@fonsp Thanks for catching this! I believe I made a mistake in #50 that assumes `IOContext` downsamples image by default -- but we should not.

For the `ImageShow.preview(img)` thing, people might just refer to `ImageBase.restrict` or `ImageTransformations.imresize`.