### PR TITLE
Include simshow function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,10 @@
 name = "ImageShow"
 uuid = "4e3cecfd-b093-5904-9786-8bbb286a6a31"
-version = "0.3.6"
+version = "0.3.7"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ImageBase = "c817782e-172a-44cc-b673-b171935fbb9e"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
@@ -11,6 +12,7 @@ OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 StackViews = "cae243ae-269e-4f55-b966-ac2d0dc13c15"
 
 [compat]
+ColorSchemes = "3"
 FileIO = "1"
 ImageBase = "0.1"
 ImageCore = "0.9"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ image or 2d images as either a video sequence or a gif.
 
 - (Experimental) `play`/`explore` are interactive tools; it show images frame by frame as video sequence.
 - `gif` is non-interactive; it encodes the image as gif.
+- `simshow` is a simple image viewer to display arrays/images within Pluto or Jupyter. Works with complex numbers too. See `?simshow` for more.
 
 Feel free to replace `gif` with `play`/`explore` and see how it works:
 

--- a/src/ImageShow.jl
+++ b/src/ImageShow.jl
@@ -8,11 +8,13 @@ import ImageBase: restrict
 using StackViews
 using ImageCore.MappedArrays
 using ImageCore.PaddedViews
+using ColorSchemes
 
 include("showmime.jl")
 include("gif.jl")
 include("multipage.jl")
 include("compat.jl")
+include("simshow.jl")
 
 # facilitate testing from importers
 testdir() = joinpath(@__DIR__,"..","test")

--- a/src/simshow.jl
+++ b/src/simshow.jl
@@ -15,11 +15,11 @@ The transforms are applied in that order.
 * `cmap=:gray` applies a colormap provided by ColorSchemes.jl. If `cmap=:gray` simply `Colors.Gray` is used
     and with different colormaps the result is an `Colors.RGB` element type
 """
-function simshow(arr::AbstractArray{<:Real}; 
+function simshow(arr::AbstractArray{T};
                  set_one=true, set_zero=false,
                  f = nothing,
-                 γ = 1,
-                 cmap=:gray)
+                 γ = one(T),
+                 cmap=:gray) where {T<:Real}
     arr = set_zero ? arr .- minimum(arr) : arr
 
     if set_one
@@ -56,7 +56,7 @@ The transforms are applied in that order.
 """
 function simshow(arr::AbstractArray{T};
                  f=nothing,
-                 absγ=1,
+                 absγ=one(T),
                  absf=nothing) where (T<:Complex)
 
     if !isnothing(f)
@@ -76,7 +76,7 @@ function simshow(arr::AbstractArray{T};
         absarr .= absarr .^ absγ
     end
 
-    angarr = angle.(arr) ./ Tr(2pi) * 360 
+    angarr = angle.(arr) ./ Tr(2pi) * Tr(360)
 
     HSV.(angarr, one(Tr), absarr)
 end

--- a/src/simshow.jl
+++ b/src/simshow.jl
@@ -1,0 +1,92 @@
+export simshow
+
+"""
+    simshow(arr; set_one=false, set_zero=false,
+                f=nothing, γ=1)
+
+Displays a real valued array . Brightness encodes magnitude.
+Works within Jupyter and Pluto.
+# Keyword args
+The transforms are applied in that order.
+* `set_zero=false` subtracts the minimum to set minimum to 1
+* `set_one=false` divides by the maximum to set maximum to 1
+* `f` applies an arbitrary function to the abs array
+* `γ` applies a gamma correction to the abs 
+* `cmap=:gray` applies a colormap provided by ColorSchemes.jl. If `cmap=:gray` simply `Colors.Gray` is used
+    and with different colormaps the result is an `Colors.RGB` element type
+"""
+function simshow(arr::AbstractArray{<:Real}; 
+                 set_one=true, set_zero=false,
+                 f = nothing,
+                 γ = 1,
+                 cmap=:gray)
+    arr = set_zero ? arr .- minimum(arr) : arr
+
+    if set_one
+        m = maximum(arr)
+        if !iszero(m)
+            arr = arr ./ maximum(arr)
+        end
+    end
+
+    arr = isnothing(f) ? arr : f(arr)
+
+    if !isone(γ)
+        arr = arr .^ γ
+    end
+
+    if cmap == :gray
+        Gray.(arr)
+    else
+        get(colorschemes[cmap], arr)
+    end
+end
+
+
+"""
+    simshow(arr)
+
+Displays a complex array. Color encodes phase, brightness encodes magnitude.
+Works within Jupyter and Pluto.
+# Keyword args
+The transforms are applied in that order.
+* `f` applies a function `f` to the array.
+* `absf` applies a function `absf` to the absolute of the array
+* `absγ` applies a gamma correction to the abs 
+"""
+function simshow(arr::AbstractArray{T};
+                 f=nothing,
+                 absγ=1,
+                 absf=nothing) where (T<:Complex)
+
+    if !isnothing(f)
+        arr = f(arr)
+    end
+
+    Tr = real(T)
+    # scale abs to 1
+    absarr = abs.(arr)
+    absarr ./= maximum(absarr)
+
+    if !isnothing(absf)
+        absarr .= absf(absarr)
+    end
+    
+    if !isone(absγ)
+        absarr .= absarr .^ absγ
+    end
+
+    angarr = angle.(arr) ./ Tr(2pi) * 360 
+
+    HSV.(angarr, one(Tr), absarr)
+end
+
+
+
+"""
+    simshow(arr::AbstractArray{<:Colors.ColorTypes.Colorant})
+If `simshow` receives an array which already contains color information, just display it.
+"""
+function simshow(arr::AbstractArray{<:Colors.ColorTypes.Colorant})
+    return arr
+end

--- a/src/simshow.jl
+++ b/src/simshow.jl
@@ -13,8 +13,8 @@ The transforms are applied in that order.
 * `set_one=true` divides by the maximum to set maximum to 1
 * `γ` applies a gamma correction
 * `cmap=:gray` applies a colormap provided by ColorSchemes.jl. If `cmap=:gray` simply `Colors.Gray` is used
-    and with different colormaps the result is an `Colors.RGB` element type. To use the different colormaps
-    install ColorSchemes.jl and try colormaps such as `:jet`, `:deep`, `thermal`, etc.
+    and with different colormaps the result is an `Colors.RGB` element type.  
+    You can try `:jet`, `:deep`, `thermal` or different ones by reading the catalogue of ColorSchemes.jl
 """
 function simshow(arr::AbstractArray{T};
                  set_zero=false, set_one=true,

--- a/src/simshow.jl
+++ b/src/simshow.jl
@@ -52,7 +52,7 @@ Works within Jupyter and Pluto.
 * `γ` applies a gamma correction to the magnitude
 """
 function simshow(arr::AbstractArray{T};
-                 γ=one(T)) where (T<:Complex)
+                 γ=one(T), kwargs...) where (T<:Complex)
 
     Tr = real(T)
     # scale abs to 1

--- a/src/simshow.jl
+++ b/src/simshow.jl
@@ -9,8 +9,8 @@ Works within Jupyter and Pluto.
 # Keyword args
 
 The transforms are applied in that order.
-* `set_zero=false` subtracts the minimum to set minimum to 1
-* `set_one=false` divides by the maximum to set maximum to 1
+* `set_zero=false` subtracts the minimum to set minimum to 0
+* `set_one=true` divides by the maximum to set maximum to 1
 * `γ` applies a gamma correction to the abs 
 * `cmap=:gray` applies a colormap provided by ColorSchemes.jl. If `cmap=:gray` simply `Colors.Gray` is used
     and with different colormaps the result is an `Colors.RGB` element type

--- a/src/simshow.jl
+++ b/src/simshow.jl
@@ -1,7 +1,7 @@
 export simshow
 
 """
-    simshow(arr; set_one=false, set_zero=false, γ=1)
+    simshow(arr; set_zero=false, set_one=false, γ=1)
 
 Displays a real valued array . Brightness encodes magnitude.
 Works within Jupyter and Pluto.
@@ -16,7 +16,7 @@ The transforms are applied in that order.
     and with different colormaps the result is an `Colors.RGB` element type
 """
 function simshow(arr::AbstractArray{T};
-                 set_one=true, set_zero=false,
+                 set_zero=false, set_one=true,
                  γ = one(T),
                  cmap=:gray) where {T<:Real}
 

--- a/src/simshow.jl
+++ b/src/simshow.jl
@@ -1,9 +1,9 @@
 export simshow
 
 """
-    simshow(arr; set_zero=false, set_one=false, γ=1)
+    simshow(arr; set_zero=false, set_one=false, γ=1, cmap=:gray)
 
-Displays a real valued array . Brightness encodes magnitude.
+Displays a real valued array.
 Works within Jupyter and Pluto.
 
 # Keyword args
@@ -11,9 +11,10 @@ Works within Jupyter and Pluto.
 The transforms are applied in that order.
 * `set_zero=false` subtracts the minimum to set minimum to 0
 * `set_one=true` divides by the maximum to set maximum to 1
-* `γ` applies a gamma correction to the abs 
+* `γ` applies a gamma correction
 * `cmap=:gray` applies a colormap provided by ColorSchemes.jl. If `cmap=:gray` simply `Colors.Gray` is used
-    and with different colormaps the result is an `Colors.RGB` element type
+    and with different colormaps the result is an `Colors.RGB` element type. To use the different colormaps
+    install ColorSchemes.jl and try colormaps such as `:jet`, `:deep`, `thermal`, etc.
 """
 function simshow(arr::AbstractArray{T};
                  set_zero=false, set_one=true,
@@ -42,15 +43,13 @@ end
 
 
 """
-    simshow(arr)
+    simshow(arr; γ=1)
 
 Displays a complex array. Color encodes phase, brightness encodes magnitude.
 Works within Jupyter and Pluto.
 
 # Keyword args
-
-The transforms are applied in that order.
-* `γ` applies a gamma correction to the abs 
+* `γ` applies a gamma correction to the magnitude
 """
 function simshow(arr::AbstractArray{T};
                  γ=one(T)) where (T<:Complex)
@@ -69,12 +68,19 @@ function simshow(arr::AbstractArray{T};
     HSV.(angarr, one(Tr), absarr)
 end
 
+"""
+    simshow(arr::AbstractArray{Colors.Gray{<: Fixed}})
 
+"""
+function simshow(arr::AbstractArray{Colors.Gray{T}}) where {T<:Fixed}
+    return simshow(Array{Gray{Float64}}(arr))
+end
 
 """
     simshow(arr::AbstractArray{<:Colors.ColorTypes.Colorant})
 
 If `simshow` receives an array which already contains color information, just display it.
+In that case, no keywords argument are applied.
 """
 function simshow(arr::AbstractArray{<:Colors.ColorTypes.Colorant})
     return arr

--- a/src/simshow.jl
+++ b/src/simshow.jl
@@ -5,7 +5,9 @@ export simshow
 
 Displays a real valued array . Brightness encodes magnitude.
 Works within Jupyter and Pluto.
+
 # Keyword args
+
 The transforms are applied in that order.
 * `set_zero=false` subtracts the minimum to set minimum to 1
 * `set_one=false` divides by the maximum to set maximum to 1

--- a/src/simshow.jl
+++ b/src/simshow.jl
@@ -1,8 +1,7 @@
 export simshow
 
 """
-    simshow(arr; set_one=false, set_zero=false,
-                f=nothing, γ=1)
+    simshow(arr; set_one=false, set_zero=false, γ=1)
 
 Displays a real valued array . Brightness encodes magnitude.
 Works within Jupyter and Pluto.
@@ -10,16 +9,15 @@ Works within Jupyter and Pluto.
 The transforms are applied in that order.
 * `set_zero=false` subtracts the minimum to set minimum to 1
 * `set_one=false` divides by the maximum to set maximum to 1
-* `f` applies an arbitrary function to the abs array
 * `γ` applies a gamma correction to the abs 
 * `cmap=:gray` applies a colormap provided by ColorSchemes.jl. If `cmap=:gray` simply `Colors.Gray` is used
     and with different colormaps the result is an `Colors.RGB` element type
 """
 function simshow(arr::AbstractArray{T};
                  set_one=true, set_zero=false,
-                 f = nothing,
                  γ = one(T),
                  cmap=:gray) where {T<:Real}
+
     arr = set_zero ? arr .- minimum(arr) : arr
 
     if set_one
@@ -28,8 +26,6 @@ function simshow(arr::AbstractArray{T};
             arr = arr ./ maximum(arr)
         end
     end
-
-    arr = isnothing(f) ? arr : f(arr)
 
     if !isone(γ)
         arr = arr .^ γ
@@ -48,32 +44,22 @@ end
 
 Displays a complex array. Color encodes phase, brightness encodes magnitude.
 Works within Jupyter and Pluto.
+
 # Keyword args
+
 The transforms are applied in that order.
-* `f` applies a function `f` to the array.
-* `absf` applies a function `absf` to the absolute of the array
-* `absγ` applies a gamma correction to the abs 
+* `γ` applies a gamma correction to the abs 
 """
 function simshow(arr::AbstractArray{T};
-                 f=nothing,
-                 absγ=one(T),
-                 absf=nothing) where (T<:Complex)
-
-    if !isnothing(f)
-        arr = f(arr)
-    end
+                 γ=one(T)) where (T<:Complex)
 
     Tr = real(T)
     # scale abs to 1
     absarr = abs.(arr)
     absarr ./= maximum(absarr)
 
-    if !isnothing(absf)
-        absarr .= absf(absarr)
-    end
-    
-    if !isone(absγ)
-        absarr .= absarr .^ absγ
+    if !isone(γ)
+        absarr .= absarr .^ γ
     end
 
     angarr = angle.(arr) ./ Tr(2pi) * Tr(360)
@@ -85,6 +71,7 @@ end
 
 """
     simshow(arr::AbstractArray{<:Colors.ColorTypes.Colorant})
+
 If `simshow` receives an array which already contains color information, just display it.
 """
 function simshow(arr::AbstractArray{<:Colors.ColorTypes.Colorant})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,4 +6,5 @@ using Test
     include("gif.jl")
     include("keyboard.jl")
     include("multipage.jl")
+    include("simshow.jl")
 end

--- a/test/simshow.jl
+++ b/test/simshow.jl
@@ -3,7 +3,7 @@
     @test simshow([1, 2, 3, 4]) == ColorTypes.Gray{Float64}[Gray{Float64}(0.25), Gray{Float64}(0.5), Gray{Float64}(0.75), Gray{Float64}(1.0)]
     @test simshow([0.1, 0.1], set_one = true) == ColorTypes.Gray{Float64}[Gray{Float64}(1.0), Gray{Float64}(1.0)]
     @test simshow([0.1, 0.1], set_one = false) == ColorTypes.Gray{Float64}[Gray{Float64}(0.1), Gray{Float64}(0.1)]
-    @test simshow([0.1, 0.1], set_one = false) == ColorTypes.Gray{Float64}[Gray{Float64}(0.1), Gray{Float64}(0.1)]
+    @test simshow([0.1f0, 0.1f0], set_one = false) == ColorTypes.Gray{Float32}[Gray{Float32}(0.1), Gray{Float32}(0.1f0)]
     @test simshow([0.1, -0.1], set_one = true, set_zero = false) == ColorTypes.Gray{Float64}[Gray{Float64}(1.0), Gray{Float64}(-1.0)]
     @test simshow([0.1, -0.1], set_one = true, set_zero = true) == ColorTypes.Gray{Float64}[Gray{Float64}(1.0), Gray{Float64}(0.0)]
     @test simshow([0.1, -0.1], set_one = false, set_zero = true) == ColorTypes.Gray{Float64}[Gray{Float64}(0.2), Gray{Float64}(0.0)]

--- a/test/simshow.jl
+++ b/test/simshow.jl
@@ -1,0 +1,39 @@
+@testset "Real Arrays" begin
+
+    @test simshow([1, 2, 3, 4]) == ColorTypes.Gray{Float64}[Gray{Float64}(0.25), Gray{Float64}(0.5), Gray{Float64}(0.75), Gray{Float64}(1.0)]
+    @test simshow([0.1, 0.1], set_one = true) == ColorTypes.Gray{Float64}[Gray{Float64}(1.0), Gray{Float64}(1.0)]
+    @test simshow([0.1, 0.1], set_one = false) == ColorTypes.Gray{Float64}[Gray{Float64}(0.1), Gray{Float64}(0.1)]
+    @test simshow([0.1, 0.1], set_one = false) == ColorTypes.Gray{Float64}[Gray{Float64}(0.1), Gray{Float64}(0.1)]
+    @test simshow([0.1, -0.1], set_one = true, set_zero = false) == ColorTypes.Gray{Float64}[Gray{Float64}(1.0), Gray{Float64}(-1.0)]
+    @test simshow([0.1, -0.1], set_one = true, set_zero = true) == ColorTypes.Gray{Float64}[Gray{Float64}(1.0), Gray{Float64}(0.0)]
+    @test simshow([0.1, -0.1], set_one = false, set_zero = true) == ColorTypes.Gray{Float64}[Gray{Float64}(0.2), Gray{Float64}(0.0)]
+    @test simshow([0.1, -0.1], set_one = false, set_zero = false) == ColorTypes.Gray{Float64}[Gray{Float64}(0.1), Gray{Float64}(-0.1)]
+    @test simshow([0.1, 0], γ = 2, set_one = false) == ColorTypes.Gray{Float64}[Gray{Float64}(0.010000000000000002), Gray{Float64}(0.0)]
+    @test simshow([0.1, 0], f = (x-> zeros((2,))), set_one = false) == ColorTypes.Gray{Float64}[Gray{Float64}(0.0), Gray{Float64}(0.0)]
+
+
+    @test simshow([0, 1, 2], cmap = :thermal) == ColorTypes.RGB{Float64}[RGB{Float64}(0.015556013331540799,0.13824424546464084,0.2018108864558305), RGB{Float64}(0.6893346807608062,0.37270416310862364,0.5096912535037159), RGB{Float64}(0.9090418416674036,0.9821574063216706,0.3555078064299531)]
+
+end
+
+
+@testset "Complex Arrays" begin
+    @test simshow([1.0, 1im, -1, -1im, 1.0 - 0.0001im]) == ColorTypes.HSV{Float64}[HSV{Float64}(0.0,1.0,0.999999995), HSV{Float64}(90.0,1.0,0.999999995), HSV{Float64}(180.0,1.0,0.999999995), HSV{Float64}(-90.0,1.0,0.999999995), HSV{Float64}(-0.00572957793220964,1.0,1.0)]
+
+    @test simshow([1.0 / 2, (1im) / 2, -1 / 2, (-1im) / 2, 1.0 - 0.0001im], absγ = 2) == ColorTypes.HSV{Float64}[HSV{Float64}(0.0,1.0,0.24999999750000002), HSV{Float64}(90.0,1.0,0.24999999750000002), HSV{Float64}(180.0,1.0,0.24999999750000002), HSV{Float64}(-90.0,1.0,0.24999999750000002), HSV{Float64}(-0.00572957793220964,1.0,1.0)]
+
+
+    @test simshow([1.0, (1im) / 4, -1 / 8, (-1im) / 2, 1.0 - 0.0001im], absf = (x->begin
+                y = copy(x)
+                y .= x[1]
+                y
+            end)) == ColorTypes.HSV{Float64}[HSV{Float64}(0.0,1.0,0.999999995), HSV{Float64}(90.0,1.0,0.999999995), HSV{Float64}(180.0,1.0,0.999999995), HSV{Float64}(-90.0,1.0,0.999999995), HSV{Float64}(-0.00572957793220964,1.0,0.999999995)]
+    simshow([0.1, 0im], f = (x->begin
+                1.1 .* ones(ComplexF32, (2,))
+            end)) == HSV{Float64}[HSV{Float64}(0.0,1.0,1.0), HSV{Float64}(0.0,1.0,1.0)]
+end
+
+@testset "Colorant Array" begin
+    @test simshow(ColorTypes.Gray.([0.123])) == ColorTypes.Gray{Float64}[Gray{Float64}(0.123)]
+
+end

--- a/test/simshow.jl
+++ b/test/simshow.jl
@@ -9,7 +9,6 @@
     @test simshow([0.1, -0.1], set_one = false, set_zero = true) == ColorTypes.Gray{Float64}[Gray{Float64}(0.2), Gray{Float64}(0.0)]
     @test simshow([0.1, -0.1], set_one = false, set_zero = false) == ColorTypes.Gray{Float64}[Gray{Float64}(0.1), Gray{Float64}(-0.1)]
     @test simshow([0.1, 0], γ = 2, set_one = false) == ColorTypes.Gray{Float64}[Gray{Float64}(0.010000000000000002), Gray{Float64}(0.0)]
-    @test simshow([0.1, 0], f = (x-> zeros((2,))), set_one = false) == ColorTypes.Gray{Float64}[Gray{Float64}(0.0), Gray{Float64}(0.0)]
 
 
     @test simshow([0, 1, 2], cmap = :thermal) == ColorTypes.RGB{Float64}[RGB{Float64}(0.015556013331540799,0.13824424546464084,0.2018108864558305), RGB{Float64}(0.6893346807608062,0.37270416310862364,0.5096912535037159), RGB{Float64}(0.9090418416674036,0.9821574063216706,0.3555078064299531)]
@@ -20,17 +19,14 @@ end
 @testset "Complex Arrays" begin
     @test simshow([1.0, 1im, -1, -1im, 1.0 - 0.0001im]) == ColorTypes.HSV{Float64}[HSV{Float64}(0.0,1.0,0.999999995), HSV{Float64}(90.0,1.0,0.999999995), HSV{Float64}(180.0,1.0,0.999999995), HSV{Float64}(-90.0,1.0,0.999999995), HSV{Float64}(-0.00572957793220964,1.0,1.0)]
 
-    @test simshow([1.0 / 2, (1im) / 2, -1 / 2, (-1im) / 2, 1.0 - 0.0001im], absγ = 2) == ColorTypes.HSV{Float64}[HSV{Float64}(0.0,1.0,0.24999999750000002), HSV{Float64}(90.0,1.0,0.24999999750000002), HSV{Float64}(180.0,1.0,0.24999999750000002), HSV{Float64}(-90.0,1.0,0.24999999750000002), HSV{Float64}(-0.00572957793220964,1.0,1.0)]
-
-
-    @test simshow([1.0, (1im) / 4, -1 / 8, (-1im) / 2, 1.0 - 0.0001im], absf = (x->begin
+    @test simshow([1.0 / 2, (1im) / 2, -1 / 2, (-1im) / 2, 1.0 - 0.0001im], γ = 2) == ColorTypes.HSV{Float64}[HSV{Float64}(0.0,1.0,0.24999999750000002), HSV{Float64}(90.0,1.0,0.24999999750000002), HSV{Float64}(180.0,1.0,0.24999999750000002), HSV{Float64}(-90.0,1.0,0.24999999750000002), HSV{Float64}(-0.00572957793220964,1.0,1.0)]
+    absf = (x->begin
                 y = copy(x)
                 y .= x[1]
                 y
-            end)) == ColorTypes.HSV{Float64}[HSV{Float64}(0.0,1.0,0.999999995), HSV{Float64}(90.0,1.0,0.999999995), HSV{Float64}(180.0,1.0,0.999999995), HSV{Float64}(-90.0,1.0,0.999999995), HSV{Float64}(-0.00572957793220964,1.0,0.999999995)]
-    simshow([0.1, 0im], f = (x->begin
-                1.1 .* ones(ComplexF32, (2,))
-            end)) == HSV{Float64}[HSV{Float64}(0.0,1.0,1.0), HSV{Float64}(0.0,1.0,1.0)]
+            end)
+
+    @test simshow([1.1 + 0im, 1.1]) == HSV{Float64}[HSV{Float64}(0.0,1.0,1.0), HSV{Float64}(0.0,1.0,1.0)]
 end
 
 @testset "Colorant Array" begin


### PR DESCRIPTION
As discussed in #55 

Would be happy to receive feedback :)


Right now it basically displays only 2D arrays.

I think it would be nice to have the option for 3D arrays to be shown as RGB, if possible.

For other 3D arrays I think we can just error because `simshow` is not a fully fledged viewer but instead a simple viewer for inline displays of arrays