### PR TITLE
[compat] ImageCore 0.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ImageShow"
 uuid = "4e3cecfd-b093-5904-9786-8bbb286a6a31"
-version = "0.3.7"
+version = "0.3.8"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -15,7 +15,7 @@ StackViews = "cae243ae-269e-4f55-b966-ac2d0dc13c15"
 ColorSchemes = "3"
 FileIO = "1"
 ImageBase = "0.1"
-ImageCore = "0.9"
+ImageCore = "0.9, 0.10"
 OffsetArrays = "0.8, 0.9, 0.10, 0.11, 1"
 StackViews = "0.1.1"
 julia = "1"


### PR DESCRIPTION
For me, tests require https://github.com/JuliaIO/ImageIO.jl/pull/62 to pass. But might as well get this submitted now.