### PR TITLE
Fix bug with division by zero in complex simshow

### DIFF
--- a/src/simshow.jl
+++ b/src/simshow.jl
@@ -57,7 +57,10 @@ function simshow(arr::AbstractArray{T};
     Tr = real(T)
     # scale abs to 1
     absarr = abs.(arr)
-    absarr ./= maximum(absarr)
+    m = maximum(absarr)
+    if !iszero(m)
+        absarr ./= maximum(absarr)
+    end
 
     if !isone(γ)
         absarr .= absarr .^ γ


### PR DESCRIPTION
Hi,

just a division by zero bug which causes hard errors inside Pluto:
```julia
# master
julia> simshow(zeros(ComplexF32,(2,2)))
2×2 Array{HSV{Float32},2} with eltype ColorTypes.HSV{Float32}:
 HSV{Float32}(0.0,1.0,NaN)  HSV{Float32}(0.0,1.0,NaN)
 HSV{Float32}(0.0,1.0,NaN)  HSV{Float32}(0.0,1.0,NaN)

# fix
julia> simshow(zeros(ComplexF32,(2,2)))
2×2 Array{HSV{Float32},2} with eltype ColorTypes.HSV{Float32}:
 HSV{Float32}(0.0,1.0,0.0)  HSV{Float32}(0.0,1.0,0.0)
 HSV{Float32}(0.0,1.0,0.0)  HSV{Float32}(0.0,1.0,0.0)

```