### PR TITLE
html show method: use IOContext from original renderer

### DIFF
--- a/src/showmime.jl
+++ b/src/showmime.jl
@@ -145,7 +145,7 @@ function show_element(io::IOContext, img, thumbnail=false; mimes=_HTML_IMAGE_MIM
         img
     end
     io2=IOBuffer()
-    b64pipe=Base64EncodePipe(io2)
+    b64pipe=IOContext(Base64EncodePipe(io2), io)
     for mime in mimes
         if showable(mime, img)
             show(b64pipe, mime, img)


### PR DESCRIPTION
Hey! I was working on https://discourse.julialang.org/t/making-images-as-big-as-possible-max-width-in-pluto-notebooks/115003/14 and noticed that when the HTML show method is used from ImageShow, any properties from the io context are ignored.

In particular, it is not possible to use the `:full_fidelity` property to control the HTML show method.

You can see this in this example:

# Before

```julia
julia> using Colors, ImageShow, ImageIO

julia> img = rand(Gray, 2000, 2000);

julia> sprint() do io
                  show(io, MIME"text/html"(), img)
              end
249546

julia> sprint() do io
                  show(IOContext(io, :full_fidelity=>true), MIME"text/html"(), img)
              end |> length
249546

```

(the two outputs are the same)

# After


```julia
julia> using Colors, ImageShow, ImageIO

julia> img = rand(Gray, 2000, 2000);

julia> sprint() do io
           show(io, MIME"text/html"(), img)
       end |> length
249658

julia> sprint() do io
           show(IOContext(io, :full_fidelity=>true), MIME"text/html"(), img)
       end |> length
5345654

```

(different, because `full_fidelity` has an effect)
